### PR TITLE
P1: sandwich economics — reserves, feasibility gate & optimal-input math

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ WSS_URL=ws://127.0.0.1:8546
 PRIVATE_KEY="provide your private key "
 FLASHBOTS_AUTH_KEY="provide your flashbots auth key"
 SANDWICH_CONTRACT="provide your sandwhicher contract"
+# Max capital (in ETH) the optimal-input search will commit to a single frontrun. Defaults to 1.
+MAX_FRONTRUN_ETH=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.3.3",
+        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "ts-node tests/poolMath.test.ts",
+    "typecheck": "tsc --noEmit",
     "start": "ts-node-dev  src/index.ts"
   },
   "keywords": [],
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.3.3",
+    "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,9 @@
+import { utils } from "ethers";
 import { Logging } from "../logging/logging";
 
 require("dotenv").config();
+
+const ethersParseEther = (v: string) => utils.parseEther(v);
 
 // Accept either WSS_URL or the older RPC_URL_WSS name used in .env.example.
 const WSS_URL = process.env.WSS_URL ?? process.env.RPC_URL_WSS;
@@ -18,7 +21,12 @@ export const config = {
   ],
   
   UNIV2_ROUTER: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", //uniswapV2 router contract
+  UNIV2_FACTORY: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f", //uniswapV2 factory contract
   SANDWICH: process.env.SANDWICH_CONTRACT!, // sandwhicher contract
+
+  // Capital cap for a single frontrun, in wei. The optimal-input search never
+  // bets more than this regardless of how profitable a victim looks.
+  MAX_FRONTRUN_WEI: ethersParseEther(process.env.MAX_FRONTRUN_ETH ?? "1"),
 
   WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", //weth
   USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" ,//usdc

--- a/src/core/mempool.ts
+++ b/src/core/mempool.ts
@@ -7,6 +7,9 @@ import {
   FEE_ON_TRANSFER_METHODS,
   SANDWICHABLE_METHODS,
 } from "../utils";
+import { reserveManager } from "./reserves";
+import { computeOptimalSandwich } from "./poolMath";
+import { ethers as ethersLib } from "ethers";
 
 /** Reconnect backoff bounds for the websocket provider (ms). */
 const RECONNECT_MIN_DELAY = 1_000;
@@ -47,7 +50,7 @@ class mempool {
 
       this._wsprovider
         .getTransaction(txHash)
-        .then((tx) => tx?.hash && this.processTransaction(tx))
+        .then((tx) => (tx?.hash ? this.processTransaction(tx) : undefined))
         .catch((error) => Logging.logError(error));
     });
 
@@ -98,7 +101,9 @@ class mempool {
     this._seen.add(txHash);
   };
 
-  private processTransaction = (txReceipt: providers.TransactionResponse) => {
+  private processTransaction = async (
+    txReceipt: providers.TransactionResponse
+  ) => {
     const router = txReceipt.to;
 
     // Only consider transactions going through a supported router.
@@ -152,6 +157,68 @@ class mempool {
         maxFeePerGas: gas.maxFeePerGas?.toString() ?? null,
         maxPriorityFeePerGas: gas.maxPriorityFeePerGas?.toString() ?? null,
       },
+    });
+
+    await this.evaluateSandwich(swap, txReceipt.hash);
+  };
+
+  /**
+   * Feasibility gate + optimal-input calculation for a detected swap.
+   *
+   * For this first cut we only sandwich the simple, common case: an exact-input
+   * buy of a token directly with WETH (2-hop path WETH -> TOKEN). Token sells,
+   * exact-output swaps, and multi-hop paths are recognised but skipped — they
+   * need their own models and are tracked for a later pass.
+   */
+  private evaluateSandwich = async (
+    swap: ReturnType<typeof HelpersWrapper.extractSwapDetails>,
+    hash: string
+  ) => {
+    if (!swap) return;
+
+    const weth = config.WETH.toLowerCase();
+    const isDirectWethBuy =
+      swap.kind === "exactIn" &&
+      swap.amountIn != null &&
+      swap.path.length === 2 &&
+      swap.path[0].toLowerCase() === weth;
+
+    if (!isDirectWethBuy) {
+      Logging.logTrace(`skip ${hash}: not a direct WETH->token exact-in buy`);
+      return;
+    }
+
+    const tokenOut = swap.path[1];
+    const reserves = await reserveManager.getReserves(config.WETH, tokenOut);
+    if (!reserves) {
+      Logging.logTrace(`skip ${hash}: no WETH/${tokenOut} pool`);
+      return;
+    }
+
+    const quote = computeOptimalSandwich({
+      victimIn: swap.amountIn!,
+      victimMinOut: swap.amountOutMin ?? ethersLib.BigNumber.from(0),
+      reserveIn: reserves.reserveIn, // WETH reserve
+      reserveOut: reserves.reserveOut, // token reserve
+      maxFrontrun: config.MAX_FRONTRUN_WEI,
+    });
+
+    if (!quote) {
+      Logging.logTrace(`skip ${hash}: no profitable frontrun`);
+      return;
+    }
+
+    // Gross profit only — gas + bribe accounting and simulation come next (P1
+    // executor/bundle work). This is the input to that net-profit decision.
+    Logging.logSuccess(`candidate sandwich for ${hash}`);
+    console.log({
+      pair: reserves.pair,
+      token: tokenOut,
+      frontrunIn: ethersLib.utils.formatEther(quote.frontrunIn),
+      tokensBought: quote.tokensBought.toString(),
+      victimOut: quote.victimOut.toString(),
+      backrunOut: ethersLib.utils.formatEther(quote.backrunOut),
+      grossProfitWeth: ethersLib.utils.formatEther(quote.grossProfit),
     });
   };
 }

--- a/src/core/poolMath.ts
+++ b/src/core/poolMath.ts
@@ -1,0 +1,196 @@
+import { BigNumber } from "ethers";
+
+/**
+ * UniswapV2 constant-product (x*y=k) math and the sandwich profit model.
+ *
+ * Everything here is pure integer math on BigNumber so it can be unit-tested
+ * deterministically (see tests/poolMath.test.ts) and matches the on-chain
+ * UniswapV2Library exactly (0.30% fee => 997/1000).
+ */
+
+const FEE_NUMERATOR = BigNumber.from(997);
+const FEE_DENOMINATOR = BigNumber.from(1000);
+const ZERO = BigNumber.from(0);
+
+/** Exact analogue of UniswapV2Library.getAmountOut. */
+export function getAmountOut(
+  amountIn: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber
+): BigNumber {
+  if (amountIn.lte(0) || reserveIn.lte(0) || reserveOut.lte(0)) return ZERO;
+  const amountInWithFee = amountIn.mul(FEE_NUMERATOR);
+  const numerator = amountInWithFee.mul(reserveOut);
+  const denominator = reserveIn.mul(FEE_DENOMINATOR).add(amountInWithFee);
+  return numerator.div(denominator);
+}
+
+/** Exact analogue of UniswapV2Library.getAmountIn. */
+export function getAmountIn(
+  amountOut: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber
+): BigNumber {
+  if (amountOut.lte(0) || reserveIn.lte(0) || reserveOut.lte(0)) return ZERO;
+  if (amountOut.gte(reserveOut)) return BigNumber.from(0); // not satisfiable
+  const numerator = reserveIn.mul(amountOut).mul(FEE_DENOMINATOR);
+  const denominator = reserveOut.sub(amountOut).mul(FEE_NUMERATOR);
+  return numerator.div(denominator).add(1);
+}
+
+/** What the victim receives if we frontrun their buy with `frontrunIn` WETH. */
+export function victimOutputAfterFrontrun(
+  frontrunIn: BigNumber,
+  victimIn: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber
+): BigNumber {
+  const tokensBought = getAmountOut(frontrunIn, reserveIn, reserveOut);
+  const reserveInAfter = reserveIn.add(frontrunIn);
+  const reserveOutAfter = reserveOut.sub(tokensBought);
+  return getAmountOut(victimIn, reserveInAfter, reserveOutAfter);
+}
+
+/**
+ * Largest frontrun (in WETH) that still leaves the victim's output >= their
+ * `victimMinOut`. victimOutput is monotonically decreasing in the frontrun
+ * size, so we binary-search within [0, cap].
+ *
+ * If victimMinOut is 0 (no slippage protection) the constraint never binds and
+ * we return `cap`.
+ */
+export function maxFrontrunWithinSlippage(
+  victimIn: BigNumber,
+  victimMinOut: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber,
+  cap: BigNumber
+): BigNumber {
+  if (cap.lte(0)) return ZERO;
+  if (victimMinOut.lte(0)) return cap;
+
+  // If even a zero frontrun can't satisfy the victim, it's not our concern.
+  if (victimOutputAfterFrontrun(ZERO, victimIn, reserveIn, reserveOut).lt(victimMinOut)) {
+    return ZERO;
+  }
+  // If the cap itself still satisfies the victim, the cap is the answer.
+  if (victimOutputAfterFrontrun(cap, victimIn, reserveIn, reserveOut).gte(victimMinOut)) {
+    return cap;
+  }
+
+  let lo = ZERO;
+  let hi = cap;
+  while (hi.sub(lo).gt(1)) {
+    const mid = lo.add(hi).div(2);
+    const out = victimOutputAfterFrontrun(mid, victimIn, reserveIn, reserveOut);
+    if (out.gte(victimMinOut)) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+export interface SandwichQuote {
+  /** WETH put into the frontrun buy. */
+  frontrunIn: BigNumber;
+  /** Tokens received from the frontrun (and later sold). */
+  tokensBought: BigNumber;
+  /** Tokens the victim receives (>= their amountOutMin). */
+  victimOut: BigNumber;
+  /** WETH received from the backrun sell. */
+  backrunOut: BigNumber;
+  /** WETH profit before gas/bribe: backrunOut - frontrunIn. */
+  grossProfit: BigNumber;
+}
+
+/** Evaluate the full sandwich (front -> victim -> back) for a given frontrun. */
+export function evaluateSandwich(
+  frontrunIn: BigNumber,
+  victimIn: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber
+): SandwichQuote {
+  const tokensBought = getAmountOut(frontrunIn, reserveIn, reserveOut);
+  const r1In = reserveIn.add(frontrunIn);
+  const r1Out = reserveOut.sub(tokensBought);
+
+  const victimOut = getAmountOut(victimIn, r1In, r1Out);
+  const r2In = r1In.add(victimIn);
+  const r2Out = r1Out.sub(victimOut);
+
+  // Sell our tokens back for WETH (reserves are now token-in / WETH-out).
+  const backrunOut = getAmountOut(tokensBought, r2Out, r2In);
+
+  return {
+    frontrunIn,
+    tokensBought,
+    victimOut,
+    backrunOut,
+    grossProfit: backrunOut.sub(frontrunIn),
+  };
+}
+
+/**
+ * Find the gross-profit-maximising frontrun for a victim buying `victimIn`
+ * WETH for tokens, subject to their slippage limit and a capital cap.
+ *
+ * grossProfit(frontrun) is unimodal on [0, slippageMax], so we ternary-search
+ * it. The search bound is min(slippage-bound, capital cap), which means the
+ * result is automatically min(unconstrained-optimum, slippage-bound) — i.e. we
+ * never push the victim past their amountOutMin, and we never bet more capital
+ * than allowed.
+ *
+ * Returns null when no positive-gross-profit sandwich exists (gas is applied by
+ * the caller on top of this).
+ */
+export function computeOptimalSandwich(params: {
+  victimIn: BigNumber;
+  victimMinOut: BigNumber;
+  reserveIn: BigNumber; // WETH reserve
+  reserveOut: BigNumber; // token reserve
+  maxFrontrun: BigNumber; // capital cap, in WETH
+}): SandwichQuote | null {
+  const { victimIn, victimMinOut, reserveIn, reserveOut, maxFrontrun } = params;
+
+  const upper = maxFrontrunWithinSlippage(
+    victimIn,
+    victimMinOut,
+    reserveIn,
+    reserveOut,
+    maxFrontrun
+  );
+  if (upper.lte(0)) return null;
+
+  let lo = ZERO;
+  let hi = upper;
+  const profitAt = (a: BigNumber) =>
+    evaluateSandwich(a, victimIn, reserveIn, reserveOut).grossProfit;
+
+  // Ternary search over the integer-valued unimodal profit curve.
+  while (hi.sub(lo).gt(2)) {
+    const third = hi.sub(lo).div(3);
+    const m1 = lo.add(third);
+    const m2 = hi.sub(third);
+    if (profitAt(m1).lt(profitAt(m2))) {
+      lo = m1;
+    } else {
+      hi = m2;
+    }
+  }
+
+  // Scan the small remaining window for the exact best point.
+  let best = lo;
+  let bestProfit = profitAt(lo);
+  for (let c = lo.add(1); c.lte(hi); c = c.add(1)) {
+    const p = profitAt(c);
+    if (p.gt(bestProfit)) {
+      bestProfit = p;
+      best = c;
+    }
+  }
+
+  if (bestProfit.lte(0)) return null;
+  return evaluateSandwich(best, victimIn, reserveIn, reserveOut);
+}

--- a/src/core/reserves.ts
+++ b/src/core/reserves.ts
@@ -1,0 +1,112 @@
+import { BigNumber, ethers, providers } from "ethers";
+import { config } from "../config/config";
+import { UniswapV2PairABI } from "../abi";
+
+const FACTORY_ABI = [
+  "function getPair(address tokenA, address tokenB) view returns (address)",
+];
+
+export interface PairReserves {
+  pair: string;
+  token0: string;
+  token1: string;
+  reserve0: BigNumber;
+  reserve1: BigNumber;
+  /** Reserve of `tokenIn` and `tokenOut` for convenience, oriented to a query. */
+  reserveIn: BigNumber;
+  reserveOut: BigNumber;
+}
+
+/**
+ * Resolves UniswapV2 pair addresses and fetches reserves, with a short cache so
+ * we don't re-query the same pool on every pending tx. Reserves are cached for
+ * `ttlMs` — long enough to avoid hammering the node, short enough that we act on
+ * fresh state. (P2 will replace polling with `Sync`-event subscriptions.)
+ */
+export class ReserveManager {
+  private _provider: providers.JsonRpcProvider;
+  private _factory: ethers.Contract;
+  private _pairCache = new Map<string, string>();
+  private _reserveCache = new Map<
+    string,
+    { token0: string; reserve0: BigNumber; reserve1: BigNumber; at: number }
+  >();
+  private _ttlMs: number;
+
+  constructor(rpcUrl: string = config.RPC_URL, ttlMs = 2_000) {
+    this._provider = new providers.JsonRpcProvider(rpcUrl);
+    this._factory = new ethers.Contract(
+      config.UNIV2_FACTORY,
+      FACTORY_ABI,
+      this._provider
+    );
+    this._ttlMs = ttlMs;
+  }
+
+  private pairKey = (a: string, b: string) =>
+    [a.toLowerCase(), b.toLowerCase()].sort().join(":");
+
+  /** Resolve (and cache) the pair address for two tokens. */
+  async getPairAddress(tokenA: string, tokenB: string): Promise<string | null> {
+    const key = this.pairKey(tokenA, tokenB);
+    const cached = this._pairCache.get(key);
+    if (cached) return cached;
+
+    const pair: string = await this._factory.getPair(tokenA, tokenB);
+    if (!pair || pair === ethers.constants.AddressZero) return null;
+
+    this._pairCache.set(key, pair);
+    return pair;
+  }
+
+  /**
+   * Fetch reserves for the pool that trades `tokenIn`/`tokenOut`, oriented so
+   * `reserveIn` corresponds to `tokenIn`. Returns null if the pool doesn't exist.
+   */
+  async getReserves(
+    tokenIn: string,
+    tokenOut: string
+  ): Promise<PairReserves | null> {
+    const pair = await this.getPairAddress(tokenIn, tokenOut);
+    if (!pair) return null;
+
+    let entry = this._reserveCache.get(pair);
+    const now = Date.now();
+    if (!entry || now - entry.at > this._ttlMs) {
+      const contract = new ethers.Contract(
+        pair,
+        UniswapV2PairABI,
+        this._provider
+      );
+      const [reserves, token0] = await Promise.all([
+        contract.getReserves(),
+        contract.token0(),
+      ]);
+      entry = {
+        token0: (token0 as string).toLowerCase(),
+        reserve0: reserves[0],
+        reserve1: reserves[1],
+        at: now,
+      };
+      this._reserveCache.set(pair, entry);
+    }
+
+    const token1 =
+      entry.token0 === tokenIn.toLowerCase()
+        ? tokenOut.toLowerCase()
+        : tokenIn.toLowerCase();
+    const inIsToken0 = entry.token0 === tokenIn.toLowerCase();
+
+    return {
+      pair,
+      token0: entry.token0,
+      token1,
+      reserve0: entry.reserve0,
+      reserve1: entry.reserve1,
+      reserveIn: inIsToken0 ? entry.reserve0 : entry.reserve1,
+      reserveOut: inIsToken0 ? entry.reserve1 : entry.reserve0,
+    };
+  }
+}
+
+export const reserveManager = new ReserveManager();

--- a/tests/poolMath.test.ts
+++ b/tests/poolMath.test.ts
@@ -1,0 +1,153 @@
+import assert from "assert";
+import { BigNumber } from "ethers";
+import {
+  getAmountOut,
+  getAmountIn,
+  maxFrontrunWithinSlippage,
+  evaluateSandwich,
+  computeOptimalSandwich,
+} from "../src/core/poolMath";
+
+const bn = (n: string | number) => BigNumber.from(n);
+
+let passed = 0;
+let failed = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`FAIL  ${name}`);
+    console.error(`      ${(err as Error).message}`);
+  }
+}
+
+// --- getAmountOut matches the on-chain UniswapV2Library formula ---------------
+test("getAmountOut matches reference value", () => {
+  // 1000 in, 1e6/1e6 reserves -> floor(997000*1e6 / (1e9 + 997000)) = 996
+  assert.strictEqual(getAmountOut(bn(1000), bn(1_000_000), bn(1_000_000)).toString(), "996");
+});
+
+test("getAmountOut returns 0 on degenerate inputs", () => {
+  assert.strictEqual(getAmountOut(bn(0), bn(1_000_000), bn(1_000_000)).toString(), "0");
+  assert.strictEqual(getAmountOut(bn(1000), bn(0), bn(1_000_000)).toString(), "0");
+});
+
+// --- getAmountIn is the inverse (round-trips within rounding) -----------------
+test("getAmountIn round-trips getAmountOut", () => {
+  const Rin = bn("5000000000000000000000");
+  const Rout = bn("9000000000000000000000");
+  const amountIn = bn("1000000000000000000"); // 1 token
+  const out = getAmountOut(amountIn, Rin, Rout);
+  const backIn = getAmountIn(out, Rin, Rout);
+  // getAmountIn rounds up, so backIn should be >= amountIn and very close.
+  assert.ok(backIn.gte(amountIn), `backIn ${backIn} < amountIn ${amountIn}`);
+  const diff = backIn.sub(amountIn);
+  assert.ok(diff.lte(bn("1000000000000")), `round-trip drift too large: ${diff}`);
+});
+
+// --- slippage bound: victim always still gets >= their min out ----------------
+test("maxFrontrunWithinSlippage respects victim min-out", () => {
+  const Rin = bn("100000000000000000000"); // 100 WETH
+  const Rout = bn("200000000000000000000000"); // 200k token
+  const victimIn = bn("1000000000000000000"); // 1 WETH
+  // Victim's no-frontrun output, then demand 99% of it as their min.
+  const cleanOut = getAmountOut(victimIn, Rin, Rout);
+  const minOut = cleanOut.mul(99).div(100);
+
+  const cap = bn("50000000000000000000"); // 50 WETH cap
+  const a = maxFrontrunWithinSlippage(victimIn, minOut, Rin, Rout, cap);
+
+  // At the chosen frontrun the victim still clears their min...
+  const out = evaluateSandwich(a, victimIn, Rin, Rout).victimOut;
+  assert.ok(out.gte(minOut), `victimOut ${out} < minOut ${minOut}`);
+  // ...and one wei more would (in general) violate it or hit the cap.
+  assert.ok(a.gt(0), "expected a positive frontrun bound");
+  assert.ok(a.lte(cap), "frontrun exceeded cap");
+});
+
+test("maxFrontrunWithinSlippage returns cap when victim has no protection", () => {
+  const Rin = bn("100000000000000000000");
+  const Rout = bn("200000000000000000000000");
+  const cap = bn("5000000000000000000");
+  const a = maxFrontrunWithinSlippage(bn("1000000000000000000"), bn(0), Rin, Rout, cap);
+  assert.strictEqual(a.toString(), cap.toString());
+});
+
+// --- optimal sandwich: profitable, bounded, and constraint-respecting --------
+test("computeOptimalSandwich finds a positive-profit frontrun", () => {
+  const Rin = bn("100000000000000000000"); // 100 WETH
+  const Rout = bn("200000000000000000000000"); // 200k token
+  const victimIn = bn("5000000000000000000"); // 5 WETH buy
+  const cleanOut = getAmountOut(victimIn, Rin, Rout);
+  const minOut = cleanOut.mul(90).div(100); // 10% slippage tolerance
+
+  const quote = computeOptimalSandwich({
+    victimIn,
+    victimMinOut: minOut,
+    reserveIn: Rin,
+    reserveOut: Rout,
+    maxFrontrun: bn("100000000000000000000"),
+  });
+
+  assert.ok(quote, "expected a quote");
+  assert.ok(quote!.grossProfit.gt(0), `expected positive profit, got ${quote!.grossProfit}`);
+  assert.ok(quote!.victimOut.gte(minOut), "victim pushed below min-out");
+  // Re-evaluating the returned frontrun reproduces the same profit (consistency).
+  const re = evaluateSandwich(quote!.frontrunIn, victimIn, Rin, Rout);
+  assert.strictEqual(re.grossProfit.toString(), quote!.grossProfit.toString());
+});
+
+test("computeOptimalSandwich rejects when no profit is possible", () => {
+  // Tiny victim trade in a deep pool: price impact (and thus extractable MEV)
+  // is below the rounding floor -> no profitable frontrun.
+  const Rin = bn("1000000000000000000000000"); // 1,000,000 WETH
+  const Rout = bn("1000000000000000000000000");
+  const quote = computeOptimalSandwich({
+    victimIn: bn("1"), // 1 wei
+    victimMinOut: bn(0),
+    reserveIn: Rin,
+    reserveOut: Rout,
+    maxFrontrun: bn("1000000000000000000"),
+  });
+  assert.strictEqual(quote, null);
+});
+
+test("optimal frontrun beats every other feasible frontrun", () => {
+  // Protected victim with loose (30%) slippage and a generous cap. The
+  // optimiser must return the profit-maximising frontrun within the feasible
+  // range [0, slippage-bound] — we assert that directly by sampling, without
+  // assuming where the optimum lies (boundary vs interior peak).
+  const Rin = bn("50000000000000000000"); // 50 WETH
+  const Rout = bn("100000000000000000000000"); // 100k token
+  const victimIn = bn("2000000000000000000"); // 2 WETH
+  const cap = bn("50000000000000000000");
+  const cleanOut = getAmountOut(victimIn, Rin, Rout);
+  const minOut = cleanOut.mul(70).div(100);
+
+  const upper = maxFrontrunWithinSlippage(victimIn, minOut, Rin, Rout, cap);
+  const quote = computeOptimalSandwich({
+    victimIn,
+    victimMinOut: minOut,
+    reserveIn: Rin,
+    reserveOut: Rout,
+    maxFrontrun: cap,
+  })!;
+  assert.ok(quote, "expected a quote");
+  assert.ok(quote.victimOut.gte(minOut), "victim pushed below min-out");
+
+  // No feasible frontrun (within the slippage bound) yields more gross profit.
+  for (let i = 0; i <= 40; i++) {
+    const a = upper.mul(i).div(40);
+    const p = evaluateSandwich(a, victimIn, Rin, Rout).grossProfit;
+    assert.ok(
+      quote.grossProfit.gte(p),
+      `frontrun ${a} (profit ${p}) beat the reported optimum ${quote.grossProfit}`
+    );
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Builds the profit core on top of the P0 monitor (`docs/PROFITABILITY_ANALYSIS.md` §4). The bot now goes from "decoded a swap" to "computed the optimal, slippage-respecting frontrun and its gross profit."

## What's new

**`src/core/poolMath.ts`** — pure, fully-tested BigNumber math:
- `getAmountOut` / `getAmountIn` — exact analogues of `UniswapV2Library` (0.30% fee).
- `maxFrontrunWithinSlippage` — binary-searches the largest frontrun that still leaves the victim's output ≥ their `amountOutMin` (the feasibility bound).
- `evaluateSandwich` / `computeOptimalSandwich` — full `front → victim → back` profit model; ternary-searches the gross-profit-maximising frontrun over `[0, min(slippage-bound, capital cap)]`. Returns `null` when no positive-gross-profit sandwich exists.

**`src/core/reserves.ts`** — `ReserveManager` resolves the pair via the V2 factory and fetches/caches `getReserves()`, oriented to the query token order (short TTL; `Sync`-event subscriptions are a P2 item).

**`src/core/mempool.ts`** — feasibility gate wired in: for a direct `WETH → token` exact-input buy, it fetches reserves and computes the optimal sandwich, logging a gross-profit candidate. Token sells, exact-output swaps, and multi-hop paths are recognised and skipped (each needs its own model).

**Config / tooling** — `UNIV2_FACTORY` + `MAX_FRONTRUN_WEI` (`MAX_FRONTRUN_ETH` env, default 1 ETH); a real `npm test` runner and `npm run typecheck`; `ts-node` added as an explicit devDependency.

## Notes on the math
The optimum lands at the slippage boundary in the common case — i.e. the classic result that the optimal sandwich pushes the victim to *exactly* their `amountOutMin` — while the ternary search also covers the interior-peak case (loose slippage). The "rejects when no profit is possible" test confirms tiny trades in deep pools are correctly skipped (double fee > extractable impact).

## Verification
- `npm test` → **8/8 pass** (reference values, getAmountIn round-trip, slippage-bound correctness, profitability, no-profit rejection, and an optimiser-vs-sampled-frontrun invariant).
- `npm run typecheck` (`tsc --noEmit`) → clean.

## Out of scope (next)
This computes **gross** profit. Next: an on-chain executor contract, `eth_callBundle` simulation, net-profit-aware gas/bribe bidding, and honeypot/fee-on-transfer guards (`docs/PROFITABILITY_ANALYSIS.md` §5–§7).

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_