### PR TITLE
ci: typecheck, contract compile, and tests on every push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Compile contracts
+        run: npm run compile:contracts
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # sando-mev 🔍
+
+![CI](https://github.com/henrykash/sando-mev/actions/workflows/ci.yml/badge.svg)
+
 - This is the beginning of my journey experimenting with MEV sandwicher bots using  flashbot bundlers 🧱 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow so the checks we've been running locally actually gate merges. Until now PRs went green on GitGuardian alone — `tsc`, the tests, and the contract compile never ran in CI.

## Workflow (`.github/workflows/ci.yml`)
Runs on every push to `main` and every PR:
1. `npm ci` — also verifies `package-lock.json` is in sync
2. `npm run typecheck` (`tsc --noEmit`)
3. `npm run compile:contracts` (solc validates `Sandwich.sol`)
4. `npm test` (16 unit tests)

Plus a CI status badge in the README.

## Verification
Ran the exact CI sequence locally: `npm ci` → typecheck → compile → **16/16 tests pass**.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_