### PR TITLE
backtest: replay historical swaps to estimate edge before risking capital

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ The goal of this bot is to build an optimized searcher, brick 🧱 by 🧱 .
   - doing math in Typescript
   - calculating next base fee
 
+# backtesting 📊
+Estimate edge before risking capital by replaying historical victim swaps
+through the same optimal-input + net-profit logic the live bot uses:
+
+```
+npm run backtest -- path/to/dataset.json   # defaults to the bundled sample fixture
+```
+
+The dataset is JSON (wei-string fields); see `src/backtest/fixtures/sample.json`
+for the schema. `src/backtest/loader.ts` can build a dataset from real mainnet
+flow when pointed at an archive RPC.
+
 # tech-stack
 - `Typerscript`
 - `Ethersjs`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "ts-node tests/run.ts",
     "typecheck": "tsc --noEmit",
     "compile:contracts": "node scripts/compile.js",
+    "backtest": "ts-node src/backtest/cli.ts",
     "start": "ts-node-dev  src/index.ts"
   },
   "keywords": [],

--- a/src/backtest/cli.ts
+++ b/src/backtest/cli.ts
@@ -1,0 +1,65 @@
+import * as fs from "fs";
+import * as path from "path";
+import { BigNumber } from "ethers";
+import { runBacktest, BacktestScenario, BacktestParams } from "./engine";
+import { formatReport } from "./report";
+
+/**
+ * Run a backtest from a JSON fixture of historical scenarios.
+ *
+ *   npm run backtest -- path/to/dataset.json
+ *
+ * All numeric fields are wei strings (the on-chain loader emits this shape).
+ * See src/backtest/fixtures/sample.json for the schema.
+ */
+interface RawScenario {
+  label?: string;
+  victimIn: string;
+  victimMinOut: string;
+  reserveWeth: string;
+  reserveToken: string;
+  nextBaseFee: string;
+}
+interface RawDataset {
+  params: {
+    maxFrontrun: string;
+    minMargin: string;
+    frontrunGas: string;
+    backrunGas: string;
+  };
+  scenarios: RawScenario[];
+}
+
+function load(file: string): { scenarios: BacktestScenario[]; params: BacktestParams } {
+  const raw: RawDataset = JSON.parse(fs.readFileSync(file, "utf8"));
+  const params: BacktestParams = {
+    maxFrontrun: BigNumber.from(raw.params.maxFrontrun),
+    minMargin: BigNumber.from(raw.params.minMargin),
+    frontrunGas: BigNumber.from(raw.params.frontrunGas),
+    backrunGas: BigNumber.from(raw.params.backrunGas),
+  };
+  const scenarios: BacktestScenario[] = raw.scenarios.map((s) => ({
+    label: s.label,
+    victimIn: BigNumber.from(s.victimIn),
+    victimMinOut: BigNumber.from(s.victimMinOut),
+    reserveWeth: BigNumber.from(s.reserveWeth),
+    reserveToken: BigNumber.from(s.reserveToken),
+    nextBaseFee: BigNumber.from(s.nextBaseFee),
+  }));
+  return { scenarios, params };
+}
+
+function main() {
+  const file =
+    process.argv[2] ||
+    path.join(__dirname, "fixtures", "sample.json");
+  if (!fs.existsSync(file)) {
+    console.error(`dataset not found: ${file}`);
+    process.exit(1);
+  }
+  const { scenarios, params } = load(file);
+  const report = runBacktest(scenarios, params);
+  console.log(formatReport(report));
+}
+
+main();

--- a/src/backtest/engine.ts
+++ b/src/backtest/engine.ts
@@ -1,0 +1,114 @@
+import { BigNumber } from "ethers";
+import { computeOptimalSandwich } from "../core/poolMath";
+import { evaluateProfit } from "../core/profit";
+
+/**
+ * Backtest engine.
+ *
+ * Replays historical victim swaps through the exact same logic the live bot
+ * uses (optimal-input search + net-profit/bribe accounting) so we can estimate
+ * realised edge *before* risking capital. It is pure BigNumber math: feed it
+ * scenarios (from the on-chain loader or a JSON fixture) and it returns an
+ * aggregate report.
+ *
+ * Caveat: this measures the *opportunity* (could we have profitably sandwiched
+ * this swap given the pool state), not inclusion — it does not model whether we
+ * would have won the block auction against competitors. It is an upper bound on
+ * capturable edge, useful for sizing and go/no-go decisions.
+ */
+export interface BacktestScenario {
+  /** Free-form label, e.g. block:txHash. */
+  label?: string;
+  /** Victim's WETH input. */
+  victimIn: BigNumber;
+  /** Victim's amountOutMin (slippage limit); 0 if none. */
+  victimMinOut: BigNumber;
+  /** Pool reserves at the parent block. */
+  reserveWeth: BigNumber;
+  reserveToken: BigNumber;
+  /** Projected next-block base fee at that point. */
+  nextBaseFee: BigNumber;
+}
+
+export interface BacktestParams {
+  maxFrontrun: BigNumber;
+  minMargin: BigNumber;
+  frontrunGas: BigNumber;
+  backrunGas: BigNumber;
+}
+
+export interface BacktestReport {
+  scenarios: number;
+  /** Had a positive-gross-profit optimal frontrun. */
+  feasible: number;
+  /** Cleared gas + margin (would actually fire). */
+  profitable: number;
+  /** profitable / scenarios. */
+  hitRate: number;
+  grossProfitTotal: BigNumber;
+  gasCostTotal: BigNumber;
+  bribeTotal: BigNumber;
+  netProfitTotal: BigNumber;
+  /** Best single net result, with its label. */
+  bestNet: BigNumber;
+  bestLabel?: string;
+}
+
+export function runBacktest(
+  scenarios: BacktestScenario[],
+  params: BacktestParams
+): BacktestReport {
+  let feasible = 0;
+  let profitable = 0;
+  let grossProfitTotal = BigNumber.from(0);
+  let gasCostTotal = BigNumber.from(0);
+  let bribeTotal = BigNumber.from(0);
+  let netProfitTotal = BigNumber.from(0);
+  let bestNet = BigNumber.from(0);
+  let bestLabel: string | undefined;
+
+  for (const s of scenarios) {
+    const quote = computeOptimalSandwich({
+      victimIn: s.victimIn,
+      victimMinOut: s.victimMinOut,
+      reserveIn: s.reserveWeth,
+      reserveOut: s.reserveToken,
+      maxFrontrun: params.maxFrontrun,
+    });
+    if (!quote) continue;
+    feasible++;
+
+    const decision = evaluateProfit({
+      grossProfit: quote.grossProfit,
+      nextBaseFee: s.nextBaseFee,
+      frontrunGas: params.frontrunGas,
+      backrunGas: params.backrunGas,
+      minMargin: params.minMargin,
+    });
+    if (!decision.viable) continue;
+
+    profitable++;
+    grossProfitTotal = grossProfitTotal.add(quote.grossProfit);
+    gasCostTotal = gasCostTotal.add(decision.gasCost);
+    bribeTotal = bribeTotal.add(decision.bribe);
+    netProfitTotal = netProfitTotal.add(decision.netProfit);
+
+    if (decision.netProfit.gt(bestNet)) {
+      bestNet = decision.netProfit;
+      bestLabel = s.label;
+    }
+  }
+
+  return {
+    scenarios: scenarios.length,
+    feasible,
+    profitable,
+    hitRate: scenarios.length === 0 ? 0 : profitable / scenarios.length,
+    grossProfitTotal,
+    gasCostTotal,
+    bribeTotal,
+    netProfitTotal,
+    bestNet,
+    bestLabel,
+  };
+}

--- a/src/backtest/fixtures/sample.json
+++ b/src/backtest/fixtures/sample.json
@@ -1,0 +1,42 @@
+{
+  "params": {
+    "maxFrontrun": "1000000000000000000",
+    "minMargin": "20000000000000000",
+    "frontrunGas": "120000",
+    "backrunGas": "120000"
+  },
+  "scenarios": [
+    {
+      "label": "demo:profitable-mid-pool",
+      "victimIn": "5000000000000000000",
+      "victimMinOut": "0",
+      "reserveWeth": "100000000000000000000",
+      "reserveToken": "200000000000000000000000",
+      "nextBaseFee": "20000000000"
+    },
+    {
+      "label": "demo:profitable-shallow-pool",
+      "victimIn": "10000000000000000000",
+      "victimMinOut": "0",
+      "reserveWeth": "50000000000000000000",
+      "reserveToken": "100000000000000000000000",
+      "nextBaseFee": "15000000000"
+    },
+    {
+      "label": "demo:tiny-victim-deep-pool",
+      "victimIn": "1000000000000000",
+      "victimMinOut": "0",
+      "reserveWeth": "1000000000000000000000000",
+      "reserveToken": "1000000000000000000000000",
+      "nextBaseFee": "30000000000"
+    },
+    {
+      "label": "demo:tight-slippage",
+      "victimIn": "2000000000000000000",
+      "victimMinOut": "3900000000000000000000",
+      "reserveWeth": "100000000000000000000",
+      "reserveToken": "200000000000000000000000",
+      "nextBaseFee": "25000000000"
+    }
+  ]
+}

--- a/src/backtest/loader.ts
+++ b/src/backtest/loader.ts
@@ -1,0 +1,87 @@
+import { BigNumber, ethers, providers } from "ethers";
+import { config } from "../config/config";
+import { UniswapV2RouterABI, UniswapV2PairABI } from "../abi";
+import { HelpersWrapper, SANDWICHABLE_METHODS } from "../utils";
+import { BacktestScenario } from "./engine";
+
+/**
+ * Pull real historical scenarios from an archive node so the backtest runs on
+ * actual mainnet flow rather than fixtures. Requires an *archive* RPC (state at
+ * historical blocks); a normal full node will fail the `getReserves` calls with
+ * a blockTag in the past.
+ *
+ * For each block in [fromBlock, toBlock] it finds direct WETH->token exact-in
+ * buys on the configured router and reconstructs the pool state at the parent
+ * block, producing scenarios the engine can replay.
+ */
+const FACTORY_ABI = [
+  "function getPair(address tokenA, address tokenB) view returns (address)",
+];
+
+export async function loadScenariosFromChain(
+  fromBlock: number,
+  toBlock: number,
+  rpcUrl: string = config.RPC_URL
+): Promise<BacktestScenario[]> {
+  const provider = new providers.JsonRpcProvider(rpcUrl);
+  const router = new ethers.utils.Interface(UniswapV2RouterABI);
+  const factory = new ethers.Contract(config.UNIV2_FACTORY, FACTORY_ABI, provider);
+  const weth = config.WETH.toLowerCase();
+  const out: BacktestScenario[] = [];
+
+  for (let bn = fromBlock; bn <= toBlock; bn++) {
+    const block = await provider.getBlockWithTransactions(bn);
+    if (!block) continue;
+    const parentBlock = await provider.getBlock(bn - 1);
+    const nextBaseFee = HelpersWrapper.calculateNextBlockBaseFee(parentBlock);
+
+    for (const tx of block.transactions) {
+      if (!tx.to || tx.to.toLowerCase() !== config.UNIV2_ROUTER.toLowerCase()) {
+        continue;
+      }
+      let parsed: ethers.utils.TransactionDescription;
+      try {
+        parsed = router.parseTransaction({ data: tx.data });
+      } catch {
+        continue;
+      }
+      if (!SANDWICHABLE_METHODS.has(parsed.name)) continue;
+
+      const swap = HelpersWrapper.extractSwapDetails(parsed, tx.value);
+      if (
+        !swap ||
+        swap.kind !== "exactIn" ||
+        swap.amountIn == null ||
+        swap.path.length !== 2 ||
+        swap.path[0].toLowerCase() !== weth
+      ) {
+        continue;
+      }
+
+      const token = swap.path[1];
+      const pair: string = await factory.getPair(config.WETH, token);
+      if (!pair || pair === ethers.constants.AddressZero) continue;
+
+      // Reserves as of the parent block (the state the bot would have acted on).
+      const pairContract = new ethers.Contract(pair, UniswapV2PairABI, provider);
+      const [reserves, token0] = await Promise.all([
+        pairContract.getReserves({ blockTag: bn - 1 }),
+        pairContract.token0(),
+      ]);
+      const wethIsToken0 = (token0 as string).toLowerCase() === weth;
+      const reserveWeth: BigNumber = wethIsToken0 ? reserves[0] : reserves[1];
+      const reserveToken: BigNumber = wethIsToken0 ? reserves[1] : reserves[0];
+
+      out.push({
+        label: `${bn}:${tx.hash}`,
+        victimIn: swap.amountIn,
+        victimMinOut: swap.amountOutMin ?? BigNumber.from(0),
+        reserveWeth,
+        reserveToken,
+        nextBaseFee,
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/backtest/report.ts
+++ b/src/backtest/report.ts
@@ -1,0 +1,25 @@
+import { BigNumberish, utils } from "ethers";
+import { BacktestReport } from "./engine";
+
+/** Human-readable summary of a backtest run. */
+export function formatReport(r: BacktestReport): string {
+  const eth = (v: BigNumberish) => utils.formatEther(v);
+  const pct = (n: number) => (n * 100).toFixed(1) + "%";
+
+  const lines = [
+    "================ backtest report ================",
+    `scenarios evaluated : ${r.scenarios}`,
+    `feasible (gross > 0) : ${r.feasible}`,
+    `profitable (net)     : ${r.profitable}  (hit rate ${pct(r.hitRate)})`,
+    "-------------------------------------------------",
+    `gross profit total   : ${eth(r.grossProfitTotal)} ETH`,
+    `gas cost total       : ${eth(r.gasCostTotal)} ETH`,
+    `bribe total          : ${eth(r.bribeTotal)} ETH`,
+    `net profit total     : ${eth(r.netProfitTotal)} ETH`,
+    `best single net      : ${eth(r.bestNet)} ETH${
+      r.bestLabel ? `  (${r.bestLabel})` : ""
+    }`,
+    "=================================================",
+  ];
+  return lines.join("\n");
+}

--- a/tests/backtest.test.ts
+++ b/tests/backtest.test.ts
@@ -1,0 +1,63 @@
+import assert from "assert";
+import { BigNumber, utils } from "ethers";
+import { runBacktest, BacktestScenario, BacktestParams } from "../src/backtest/engine";
+import { formatReport } from "../src/backtest/report";
+import { test } from "./harness";
+
+const eth = (v: string) => utils.parseEther(v);
+const gwei = (n: number) => BigNumber.from(n).mul(1_000_000_000);
+
+const params: BacktestParams = {
+  maxFrontrun: eth("1"),
+  minMargin: eth("0.02"),
+  frontrunGas: BigNumber.from("120000"),
+  backrunGas: BigNumber.from("120000"),
+};
+
+// A scenario that profitably sandwiches, and one that can't (tiny victim, deep pool).
+const profitable: BacktestScenario = {
+  label: "p",
+  victimIn: eth("5"),
+  victimMinOut: BigNumber.from(0),
+  reserveWeth: eth("100"),
+  reserveToken: eth("200000"),
+  nextBaseFee: gwei(20),
+};
+const unprofitable: BacktestScenario = {
+  label: "u",
+  victimIn: BigNumber.from("1000000000000000"), // 0.001 WETH
+  victimMinOut: BigNumber.from(0),
+  reserveWeth: eth("1000000"),
+  reserveToken: eth("1000000"),
+  nextBaseFee: gwei(30),
+};
+
+test("runBacktest: counts profitable vs unprofitable correctly", () => {
+  const r = runBacktest([profitable, unprofitable], params);
+  assert.strictEqual(r.scenarios, 2);
+  assert.strictEqual(r.profitable, 1);
+  assert.ok(r.netProfitTotal.gt(0), "expected positive net total");
+  assert.strictEqual(r.bestLabel, "p");
+});
+
+test("runBacktest: totals reconcile (gross = gas + bribe + net)", () => {
+  const r = runBacktest([profitable], params);
+  assert.strictEqual(
+    r.gasCostTotal.add(r.bribeTotal).add(r.netProfitTotal).toString(),
+    r.grossProfitTotal.toString()
+  );
+});
+
+test("runBacktest: empty input yields a zeroed report", () => {
+  const r = runBacktest([], params);
+  assert.strictEqual(r.scenarios, 0);
+  assert.strictEqual(r.profitable, 0);
+  assert.strictEqual(r.hitRate, 0);
+  assert.strictEqual(r.netProfitTotal.toString(), "0");
+});
+
+test("formatReport: renders without throwing and includes the hit rate", () => {
+  const out = formatReport(runBacktest([profitable, unprofitable], params));
+  assert.ok(out.includes("backtest report"));
+  assert.ok(out.includes("hit rate"));
+});

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -4,6 +4,7 @@ import "./setup"; // must come before any module that imports `config`
 import "./poolMath.test";
 import "./profit.test";
 import "./safety.test";
+import "./backtest.test";
 import { summary } from "./harness";
 
 summary();


### PR DESCRIPTION
## Summary

Adds a backtest harness so you can estimate realised edge **before** putting capital at risk — it replays historical victim swaps through the exact same optimal-input + net-profit logic the live bot uses.

## What's new

- **`src/backtest/engine.ts`** — pure `runBacktest()`: for each scenario it runs `computeOptimalSandwich` + `evaluateProfit` and aggregates feasible/profitable counts, hit rate, and gross/gas/bribe/net totals.
- **`src/backtest/report.ts`** — human-readable summary.
- **`src/backtest/loader.ts`** — optional on-chain loader that builds scenarios from real mainnet flow (reserves read at the parent block via an **archive** RPC).
- **`src/backtest/cli.ts` + `fixtures/sample.json`** — `npm run backtest -- [dataset.json]` (defaults to the bundled sample).

## Sample output
```
================ backtest report ================
scenarios evaluated : 4
feasible (gross > 0) : 3
profitable (net)     : 2  (hit rate 50.0%)
-------------------------------------------------
gross profit total   : 0.510344... ETH
gas cost total       : 0.0084 ETH
bribe total          : 0.461944... ETH
net profit total     : 0.04 ETH
best single net      : 0.02 ETH  (demo:profitable-mid-pool)
=================================================
```

## What it does / doesn't measure
It measures the **opportunity** (could we have profitably sandwiched this swap given pool state) — an upper bound on capturable edge useful for sizing and go/no-go. It does **not** model auction inclusion vs. competitors.

## Verification
- `npm test` → **20/20** (4 new backtest cases: classification, totals reconciliation, empty input, formatter).
- `tsc --noEmit` clean; `npm run backtest` runs on the sample fixture.

> Note: the CI workflow from #9 isn't on `main` yet, so this PR only shows GitGuardian until #9 merges and this branch picks it up.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_