### PR TITLE
reserves: live Sync-event subscriptions (lower latency, fresher state)

### DIFF
--- a/src/core/reserves.ts
+++ b/src/core/reserves.ts
@@ -1,5 +1,6 @@
 import { BigNumber, ethers, providers } from "ethers";
 import { config } from "../config/config";
+import { Logging } from "../logging/logging";
 import { UniswapV2PairABI } from "../abi";
 
 const FACTORY_ABI = [
@@ -17,30 +18,58 @@ export interface PairReserves {
   reserveOut: BigNumber;
 }
 
+interface PairState {
+  token0: string;
+  reserve0: BigNumber;
+  reserve1: BigNumber;
+  /** Last time this state was refreshed (event or fetch), ms. */
+  at: number;
+  /** A live Sync subscription is keeping this state fresh. */
+  subscribed: boolean;
+}
+
 /**
- * Resolves UniswapV2 pair addresses and fetches reserves, with a short cache so
- * we don't re-query the same pool on every pending tx. Reserves are cached for
- * `ttlMs` — long enough to avoid hammering the node, short enough that we act on
- * fresh state. (P2 will replace polling with `Sync`-event subscriptions.)
+ * Resolves UniswapV2 pair addresses and serves reserves.
+ *
+ * Two modes:
+ *  - **Subscription** (default, when a WSS url is available): on first access to
+ *    a pair we fetch its state once, then subscribe to its `Sync` events and
+ *    update the cache the moment reserves change — no per-tx RPC round-trip and
+ *    state that is fresh to the latest block. Subscriptions are LRU-capped.
+ *  - **Polling fallback**: if no WSS url, reserves are fetched on demand and
+ *    cached for `ttlMs`.
+ *
+ * Even when subscribed we re-fetch if the state is older than `maxStaleMs`, as a
+ * guard against a missed/dropped event.
  */
 export class ReserveManager {
   private _provider: providers.JsonRpcProvider;
+  private _wssUrl?: string;
+  private _wsProvider?: providers.WebSocketProvider;
   private _factory: ethers.Contract;
   private _pairCache = new Map<string, string>();
-  private _reserveCache = new Map<
-    string,
-    { token0: string; reserve0: BigNumber; reserve1: BigNumber; at: number }
-  >();
+  private _state = new Map<string, PairState>();
+  private _listeners = new Map<string, ethers.Contract>();
+  private _subOrder: string[] = []; // LRU order of subscribed pairs
   private _ttlMs: number;
+  private _maxStaleMs: number;
+  private _maxSubscriptions: number;
 
-  constructor(rpcUrl: string = config.RPC_URL, ttlMs = 2_000) {
+  constructor(
+    rpcUrl: string = config.RPC_URL,
+    wssUrl: string | undefined = config.WSS_URL,
+    opts: { ttlMs?: number; maxStaleMs?: number; maxSubscriptions?: number } = {}
+  ) {
     this._provider = new providers.JsonRpcProvider(rpcUrl);
+    this._wssUrl = wssUrl;
     this._factory = new ethers.Contract(
       config.UNIV2_FACTORY,
       FACTORY_ABI,
       this._provider
     );
-    this._ttlMs = ttlMs;
+    this._ttlMs = opts.ttlMs ?? 2_000;
+    this._maxStaleMs = opts.maxStaleMs ?? 60_000;
+    this._maxSubscriptions = opts.maxSubscriptions ?? 256;
   }
 
   private pairKey = (a: string, b: string) =>
@@ -60,7 +89,7 @@ export class ReserveManager {
   }
 
   /**
-   * Fetch reserves for the pool that trades `tokenIn`/`tokenOut`, oriented so
+   * Fetch reserves for the pool trading `tokenIn`/`tokenOut`, oriented so
    * `reserveIn` corresponds to `tokenIn`. Returns null if the pool doesn't exist.
    */
   async getReserves(
@@ -70,32 +99,11 @@ export class ReserveManager {
     const pair = await this.getPairAddress(tokenIn, tokenOut);
     if (!pair) return null;
 
-    let entry = this._reserveCache.get(pair);
-    const now = Date.now();
-    if (!entry || now - entry.at > this._ttlMs) {
-      const contract = new ethers.Contract(
-        pair,
-        UniswapV2PairABI,
-        this._provider
-      );
-      const [reserves, token0] = await Promise.all([
-        contract.getReserves(),
-        contract.token0(),
-      ]);
-      entry = {
-        token0: (token0 as string).toLowerCase(),
-        reserve0: reserves[0],
-        reserve1: reserves[1],
-        at: now,
-      };
-      this._reserveCache.set(pair, entry);
-    }
+    const entry = await this.ensureFresh(pair);
+    if (!entry) return null;
 
-    const token1 =
-      entry.token0 === tokenIn.toLowerCase()
-        ? tokenOut.toLowerCase()
-        : tokenIn.toLowerCase();
     const inIsToken0 = entry.token0 === tokenIn.toLowerCase();
+    const token1 = inIsToken0 ? tokenOut.toLowerCase() : tokenIn.toLowerCase();
 
     return {
       pair,
@@ -106,6 +114,104 @@ export class ReserveManager {
       reserveIn: inIsToken0 ? entry.reserve0 : entry.reserve1,
       reserveOut: inIsToken0 ? entry.reserve1 : entry.reserve0,
     };
+  }
+
+  /** Ensure we have fresh state for a pair, fetching/subscribing as needed. */
+  private async ensureFresh(pair: string): Promise<PairState | null> {
+    const now = Date.now();
+    const entry = this._state.get(pair);
+
+    if (entry) {
+      // Subscribed and recently updated, or within polling TTL: use as-is.
+      const maxAge = entry.subscribed ? this._maxStaleMs : this._ttlMs;
+      if (now - entry.at <= maxAge) {
+        if (entry.subscribed) this.touch(pair);
+        return entry;
+      }
+    }
+
+    const fetched = await this.fetchState(pair);
+    if (!fetched) return null;
+
+    if (this._wssUrl) {
+      this.subscribe(pair, fetched);
+    }
+    this._state.set(pair, fetched);
+    return fetched;
+  }
+
+  /** One-shot read of a pair's token0 + reserves. */
+  private async fetchState(pair: string): Promise<PairState | null> {
+    try {
+      const contract = new ethers.Contract(
+        pair,
+        UniswapV2PairABI,
+        this._provider
+      );
+      const [reserves, token0] = await Promise.all([
+        contract.getReserves(),
+        contract.token0(),
+      ]);
+      return {
+        token0: (token0 as string).toLowerCase(),
+        reserve0: reserves[0],
+        reserve1: reserves[1],
+        at: Date.now(),
+        subscribed: false,
+      };
+    } catch (error) {
+      Logging.logError(error);
+      return null;
+    }
+  }
+
+  private ensureWs(): providers.WebSocketProvider {
+    if (!this._wsProvider) {
+      this._wsProvider = new providers.WebSocketProvider(this._wssUrl!);
+    }
+    return this._wsProvider;
+  }
+
+  /** Subscribe to a pair's Sync events to keep reserves live. LRU-capped. */
+  private subscribe(pair: string, state: PairState) {
+    if (this._listeners.has(pair)) {
+      this.touch(pair);
+      return;
+    }
+    const ws = this.ensureWs();
+    const contract = new ethers.Contract(pair, UniswapV2PairABI, ws);
+    contract.on("Sync", (reserve0: BigNumber, reserve1: BigNumber) => {
+      const s = this._state.get(pair);
+      if (s) {
+        s.reserve0 = reserve0;
+        s.reserve1 = reserve1;
+        s.at = Date.now();
+      }
+    });
+    this._listeners.set(pair, contract);
+    state.subscribed = true;
+    this._subOrder.push(pair);
+    this.evictIfNeeded();
+  }
+
+  /** Mark a pair as most-recently-used for LRU eviction. */
+  private touch(pair: string) {
+    const i = this._subOrder.indexOf(pair);
+    if (i >= 0) this._subOrder.splice(i, 1);
+    this._subOrder.push(pair);
+  }
+
+  /** Drop the least-recently-used subscription(s) once over the cap. */
+  private evictIfNeeded() {
+    while (this._subOrder.length > this._maxSubscriptions) {
+      const victim = this._subOrder.shift();
+      if (!victim) break;
+      const contract = this._listeners.get(victim);
+      if (contract) contract.removeAllListeners("Sync");
+      this._listeners.delete(victim);
+      const s = this._state.get(victim);
+      if (s) s.subscribed = false; // will fall back to polling on next access
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the reserve manager's TTL polling with live `Sync`-event subscriptions, so the optimal-input math runs on pool state that's fresh to the latest block — without a per-tx RPC round-trip. This is a direct latency/accuracy win (`docs/PROFITABILITY_ANALYSIS.md` §5).

## How it works
- On first access to a pair, fetch its `token0` + reserves once, then subscribe to the pair's `Sync(reserve0, reserve1)` events and update the cache the instant reserves change.
- Subscriptions are **LRU-capped** (default 256 pairs); evicted pairs fall back to on-demand fetch.
- Even while subscribed, state is re-fetched if older than `maxStaleMs` (default 60s) as a guard against a missed/dropped event.
- **Polling fallback** preserved: with no WSS url, behaves like the old TTL cache.

## Why it matters
Previously every candidate could trigger a fresh `getReserves` RPC call (or serve state up to the TTL stale). Sandwich profitability is sensitive to acting on the exact pre-victim reserves; stale or slow reserves mean mispriced frontruns and missed/reverted bundles.

## Verification
- `tsc --noEmit` clean; `npm test` → **20/20** (the subscription path is network-bound I/O, consistent with the existing reserves code — no behavioural regressions in the pure suite).

## Notes
The default exported `reserveManager` now uses both the RPC url (initial reads) and the WSS url (subscriptions) from config.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb