### PR TITLE
univ3: swap detection/decoding + pool state reader (foundation)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,14 @@ export const config = {
   
   UNIV2_ROUTER: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", //uniswapV2 router contract
   UNIV2_FACTORY: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f", //uniswapV2 factory contract
+
+  // UniswapV3: two router generations (different calldata shapes) + factory/quoter.
+  V3_ROUTERS: [
+    { router: "0xE592427A0AEce92De3Edee1F18E0157C05861564", version: "v1" as const }, // SwapRouter
+    { router: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45", version: "v2" as const }, // SwapRouter02
+  ],
+  UNIV3_FACTORY: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+  UNIV3_QUOTER: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e", // QuoterV2
   SANDWICH: process.env.SANDWICH_CONTRACT!, // sandwhicher contract
 
   // Capital cap for a single frontrun, in wei. The optimal-input search never

--- a/src/core/mempool.ts
+++ b/src/core/mempool.ts
@@ -12,6 +12,8 @@ import { computeOptimalSandwich } from "./poolMath";
 import { evaluateProfit } from "./profit";
 import { checkTokenLists } from "./safety";
 import { BundleExecutor, SandwichPlan } from "./bundle";
+import { decodeV3Swap, V3RouterVersion } from "./v3/detect";
+import { v3PoolReader } from "./v3/pool";
 import { ethers as ethersLib } from "ethers";
 
 /** Reconnect backoff bounds for the websocket provider (ms). */
@@ -24,6 +26,7 @@ class mempool {
   private _wsprovider!: providers.WebSocketProvider;
   private _uniswap: ethers.utils.Interface;
   private _routers: Set<string>;
+  private _v3Routers: Map<string, V3RouterVersion>;
   private _seen: Set<string> = new Set();
   private _reconnectDelay = RECONNECT_MIN_DELAY;
   private _stopped = false;
@@ -34,6 +37,9 @@ class mempool {
     // Lower-case the router set once so per-tx comparisons are cheap.
     this._routers = new Set(
       config.SUPPORTED_ROUTERS.map((r) => r.toLowerCase())
+    );
+    this._v3Routers = new Map(
+      config.V3_ROUTERS.map((r) => [r.router.toLowerCase(), r.version])
     );
   }
 
@@ -109,9 +115,18 @@ class mempool {
     txReceipt: providers.TransactionResponse
   ) => {
     const router = txReceipt.to;
+    if (!router) return;
+    const to = router.toLowerCase();
 
-    // Only consider transactions going through a supported router.
-    if (!router || !this._routers.has(router.toLowerCase())) return;
+    // UniswapV3 routers take a separate detection path.
+    const v3Version = this._v3Routers.get(to);
+    if (v3Version) {
+      this.processV3Transaction(txReceipt, v3Version);
+      return;
+    }
+
+    // Only consider transactions going through a supported V2 router.
+    if (!this._routers.has(to)) return;
 
     let parsed: ethers.utils.TransactionDescription;
     try {
@@ -292,6 +307,63 @@ class mempool {
   private getExecutor = (): BundleExecutor => {
     if (!this._executor) this._executor = new BundleExecutor();
     return this._executor;
+  };
+
+  /**
+   * UniswapV3 detection path. Decodes the victim swap and reads the target
+   * pool's state. Sizing + firing for V3 require stateful simulation (tick math
+   * or eth_callBundle) and land in a follow-up — for now we surface the target
+   * and the pool state a sizer will consume.
+   */
+  private processV3Transaction = async (
+    txReceipt: providers.TransactionResponse,
+    version: V3RouterVersion
+  ) => {
+    const swap = decodeV3Swap(txReceipt.data, version);
+    if (!swap) return;
+
+    const weth = config.WETH.toLowerCase();
+    // First cut mirrors the V2 path: only WETH-funded buys.
+    if (swap.tokenIn !== weth) {
+      Logging.logTrace(`skip v3 ${txReceipt.hash}: input is not WETH`);
+      return;
+    }
+
+    const listCheck = checkTokenLists(swap.tokenOut);
+    if (!listCheck.ok) {
+      Logging.logTrace(`skip v3 ${txReceipt.hash}: ${listCheck.reason}`);
+      return;
+    }
+
+    const pool = await v3PoolReader.getState(
+      swap.tokenIn,
+      swap.tokenOut,
+      swap.fee
+    );
+    if (!pool) {
+      Logging.logTrace(
+        `skip v3 ${txReceipt.hash}: no pool ${swap.tokenOut}/${swap.fee}`
+      );
+      return;
+    }
+
+    Logging.logInfo("v3 target swap detected");
+    console.log({
+      hash: txReceipt.hash,
+      from: txReceipt.from,
+      method: swap.method,
+      multiHop: swap.multiHop,
+      tokenIn: swap.tokenIn,
+      tokenOut: swap.tokenOut,
+      fee: swap.fee,
+      amountIn: swap.amountIn.toString(),
+      amountOutMinimum: swap.amountOutMinimum.toString(),
+      pool: pool.pool,
+      sqrtPriceX96: pool.sqrtPriceX96.toString(),
+      liquidity: pool.liquidity.toString(),
+      tick: pool.tick,
+    });
+    // NOTE: optimal-input sizing + bundle firing for V3 are a follow-up.
   };
 }
 

--- a/src/core/v3/abi.ts
+++ b/src/core/v3/abi.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal UniswapV3 ABIs for swap detection, pool reads, and (later) quoting.
+ *
+ * There are two router generations with different calldata shapes:
+ *  - SwapRouter   (0xE592...1564): swap structs include `deadline`.
+ *  - SwapRouter02 (0x68b3...Fc45): `deadline` is dropped (handled via multicall).
+ * They share function names but NOT selectors, so we keep separate fragments and
+ * pick by router address.
+ */
+
+export const SWAP_ROUTER_V1_ABI = [
+  "function exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 deadline,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96) params) payable returns (uint256 amountOut)",
+  "function exactInput((bytes path,address recipient,uint256 deadline,uint256 amountIn,uint256 amountOutMinimum) params) payable returns (uint256 amountOut)",
+  "function exactOutputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 deadline,uint256 amountOut,uint256 amountInMaximum,uint160 sqrtPriceLimitX96) params) payable returns (uint256 amountIn)",
+  "function multicall(bytes[] data) payable returns (bytes[] results)",
+];
+
+export const SWAP_ROUTER_V2_ABI = [
+  "function exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96) params) payable returns (uint256 amountOut)",
+  "function exactInput((bytes path,address recipient,uint256 amountIn,uint256 amountOutMinimum) params) payable returns (uint256 amountOut)",
+  "function exactOutputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountOut,uint256 amountInMaximum,uint160 sqrtPriceLimitX96) params) payable returns (uint256 amountIn)",
+  "function multicall(bytes[] data) payable returns (bytes[] results)",
+  "function multicall(uint256 deadline, bytes[] data) payable returns (bytes[] results)",
+  "function multicall(bytes32 previousBlockhash, bytes[] data) payable returns (bytes[] results)",
+];
+
+export const V3_FACTORY_ABI = [
+  "function getPool(address tokenA, address tokenB, uint24 fee) view returns (address)",
+];
+
+export const V3_POOL_ABI = [
+  "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+  "function liquidity() view returns (uint128)",
+  "function token0() view returns (address)",
+  "function token1() view returns (address)",
+  "function fee() view returns (uint24)",
+];
+
+export const QUOTER_V2_ABI = [
+  "function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96) params) returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)",
+];

--- a/src/core/v3/detect.ts
+++ b/src/core/v3/detect.ts
@@ -1,0 +1,121 @@
+import { BigNumber, ethers } from "ethers";
+import { SWAP_ROUTER_V1_ABI, SWAP_ROUTER_V2_ABI } from "./abi";
+
+export type V3RouterVersion = "v1" | "v2";
+
+const IFACE: Record<V3RouterVersion, ethers.utils.Interface> = {
+  v1: new ethers.utils.Interface(SWAP_ROUTER_V1_ABI),
+  v2: new ethers.utils.Interface(SWAP_ROUTER_V2_ABI),
+};
+
+/** Normalised view of a UniswapV3 victim swap (exact-input only, for now). */
+export interface V3SwapDetails {
+  method: string;
+  /** First-hop input token (the side we'd spend, e.g. WETH). */
+  tokenIn: string;
+  /** First-hop output token. */
+  tokenOut: string;
+  /** Pool fee tier of the first hop (e.g. 500, 3000, 10000). */
+  fee: number;
+  amountIn: BigNumber;
+  /** Victim's minimum final output (slippage limit). */
+  amountOutMinimum: BigNumber;
+  recipient: string;
+  /** True if this came from a multi-hop `exactInput` (min-out is on the final hop). */
+  multiHop: boolean;
+}
+
+/**
+ * V3 swap paths are tightly packed bytes: token(20) | fee(3) | token(20) | ...
+ * Returns the first hop's [tokenIn, fee, tokenOut].
+ */
+export function decodeV3Path(
+  path: string
+): { tokenIn: string; fee: number; tokenOut: string } | null {
+  const hex = path.startsWith("0x") ? path.slice(2) : path;
+  // Need at least token(20) + fee(3) + token(20) = 43 bytes = 86 hex chars.
+  if (hex.length < 86) return null;
+  const tokenIn = "0x" + hex.slice(0, 40);
+  const fee = parseInt(hex.slice(40, 46), 16);
+  const tokenOut = "0x" + hex.slice(46, 86);
+  return { tokenIn: tokenIn.toLowerCase(), fee, tokenOut: tokenOut.toLowerCase() };
+}
+
+/** Decode one inner (non-multicall) call into a V3 swap, if it is one. */
+function decodeInner(
+  iface: ethers.utils.Interface,
+  data: string
+): V3SwapDetails | null {
+  let parsed: ethers.utils.TransactionDescription;
+  try {
+    parsed = iface.parseTransaction({ data });
+  } catch {
+    return null;
+  }
+  const p = parsed.args.params;
+
+  if (parsed.name === "exactInputSingle") {
+    return {
+      method: parsed.name,
+      tokenIn: (p.tokenIn as string).toLowerCase(),
+      tokenOut: (p.tokenOut as string).toLowerCase(),
+      fee: Number(p.fee),
+      amountIn: p.amountIn,
+      amountOutMinimum: p.amountOutMinimum,
+      recipient: p.recipient,
+      multiHop: false,
+    };
+  }
+
+  if (parsed.name === "exactInput") {
+    const hop = decodeV3Path(p.path);
+    if (!hop) return null;
+    return {
+      method: parsed.name,
+      tokenIn: hop.tokenIn,
+      tokenOut: hop.tokenOut,
+      fee: hop.fee,
+      amountIn: p.amountIn,
+      amountOutMinimum: p.amountOutMinimum,
+      recipient: p.recipient,
+      multiHop: true,
+    };
+  }
+
+  // exactOutput* and others are recognised but not sandwiched here.
+  return null;
+}
+
+/**
+ * Decode a UniswapV3 router transaction into a normalised swap. Handles both
+ * router generations and unwraps `multicall(...)`, returning the first
+ * exact-input swap found.
+ */
+export function decodeV3Swap(
+  data: string,
+  version: V3RouterVersion
+): V3SwapDetails | null {
+  const iface = IFACE[version];
+
+  // Direct (non-multicall) call?
+  const direct = decodeInner(iface, data);
+  if (direct) return direct;
+
+  // multicall: try each known overload, then decode each inner call.
+  for (const fn of ["multicall(bytes[])", "multicall(uint256,bytes[])", "multicall(bytes32,bytes[])"]) {
+    let decoded: ethers.utils.Result;
+    try {
+      decoded = iface.decodeFunctionData(fn, data);
+    } catch {
+      continue;
+    }
+    const calls: string[] = decoded.data;
+    for (const call of calls) {
+      const inner = decodeInner(iface, call);
+      if (inner) return inner;
+    }
+    return null; // it was a multicall, just nothing sandwichable inside
+  }
+
+  return null;
+}

--- a/src/core/v3/pool.ts
+++ b/src/core/v3/pool.ts
@@ -1,0 +1,86 @@
+import { BigNumber, ethers, providers } from "ethers";
+import { config } from "../../config/config";
+import { Logging } from "../../logging/logging";
+import { V3_FACTORY_ABI, V3_POOL_ABI } from "./abi";
+
+export interface V3PoolState {
+  pool: string;
+  token0: string;
+  token1: string;
+  fee: number;
+  sqrtPriceX96: BigNumber;
+  tick: number;
+  liquidity: BigNumber;
+}
+
+/**
+ * Resolves UniswapV3 pools and reads their current state (price + liquidity).
+ *
+ * This is the input a stateful sizer (tick math or eth_callBundle simulation)
+ * needs to size a V3 sandwich. Detection + this reader are the correct
+ * foundation; composing the front/victim/back legs is a follow-up because the
+ * on-chain Quoter only quotes against live state and can't model our frontrun.
+ */
+export class V3PoolReader {
+  private _provider: providers.JsonRpcProvider;
+  private _factory: ethers.Contract;
+  private _poolCache = new Map<string, string>();
+
+  constructor(rpcUrl: string = config.RPC_URL) {
+    this._provider = new providers.JsonRpcProvider(rpcUrl);
+    this._factory = new ethers.Contract(
+      config.UNIV3_FACTORY,
+      V3_FACTORY_ABI,
+      this._provider
+    );
+  }
+
+  private key = (a: string, b: string, fee: number) =>
+    [a.toLowerCase(), b.toLowerCase()].sort().join(":") + ":" + fee;
+
+  async getPoolAddress(
+    tokenA: string,
+    tokenB: string,
+    fee: number
+  ): Promise<string | null> {
+    const k = this.key(tokenA, tokenB, fee);
+    const cached = this._poolCache.get(k);
+    if (cached) return cached;
+    const pool: string = await this._factory.getPool(tokenA, tokenB, fee);
+    if (!pool || pool === ethers.constants.AddressZero) return null;
+    this._poolCache.set(k, pool);
+    return pool;
+  }
+
+  async getState(
+    tokenA: string,
+    tokenB: string,
+    fee: number
+  ): Promise<V3PoolState | null> {
+    const pool = await this.getPoolAddress(tokenA, tokenB, fee);
+    if (!pool) return null;
+    try {
+      const contract = new ethers.Contract(pool, V3_POOL_ABI, this._provider);
+      const [slot0, liquidity, token0, token1] = await Promise.all([
+        contract.slot0(),
+        contract.liquidity(),
+        contract.token0(),
+        contract.token1(),
+      ]);
+      return {
+        pool,
+        token0: (token0 as string).toLowerCase(),
+        token1: (token1 as string).toLowerCase(),
+        fee,
+        sqrtPriceX96: slot0.sqrtPriceX96,
+        tick: Number(slot0.tick),
+        liquidity,
+      };
+    } catch (error) {
+      Logging.logError(error);
+      return null;
+    }
+  }
+}
+
+export const v3PoolReader = new V3PoolReader();

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -5,6 +5,7 @@ import "./poolMath.test";
 import "./profit.test";
 import "./safety.test";
 import "./backtest.test";
+import "./v3detect.test";
 import { summary } from "./harness";
 
 summary();

--- a/tests/v3detect.test.ts
+++ b/tests/v3detect.test.ts
@@ -1,0 +1,89 @@
+import assert from "assert";
+import { ethers } from "ethers";
+import { decodeV3Swap, decodeV3Path } from "../src/core/v3/detect";
+import {
+  SWAP_ROUTER_V1_ABI,
+  SWAP_ROUTER_V2_ABI,
+} from "../src/core/v3/abi";
+import { test } from "./harness";
+
+const v1 = new ethers.utils.Interface(SWAP_ROUTER_V1_ABI);
+const v2 = new ethers.utils.Interface(SWAP_ROUTER_V2_ABI);
+const A = "0x" + "aa".repeat(20);
+const B = "0x" + "bb".repeat(20);
+const REC = "0x" + "cc".repeat(20);
+
+test("decodeV3Swap: SwapRouter02 exactInputSingle", () => {
+  const data = v2.encodeFunctionData("exactInputSingle", [
+    { tokenIn: A, tokenOut: B, fee: 3000, recipient: REC, amountIn: 1000, amountOutMinimum: 900, sqrtPriceLimitX96: 0 },
+  ]);
+  const s = decodeV3Swap(data, "v2")!;
+  assert.ok(s, "expected decode");
+  assert.strictEqual(s.method, "exactInputSingle");
+  assert.strictEqual(s.tokenIn, A.toLowerCase());
+  assert.strictEqual(s.tokenOut, B.toLowerCase());
+  assert.strictEqual(s.fee, 3000);
+  assert.strictEqual(s.amountIn.toString(), "1000");
+  assert.strictEqual(s.amountOutMinimum.toString(), "900");
+  assert.strictEqual(s.multiHop, false);
+});
+
+test("decodeV3Swap: original SwapRouter exactInputSingle (with deadline)", () => {
+  const data = v1.encodeFunctionData("exactInputSingle", [
+    { tokenIn: A, tokenOut: B, fee: 500, recipient: REC, deadline: 9999999999, amountIn: 5, amountOutMinimum: 4, sqrtPriceLimitX96: 0 },
+  ]);
+  const s = decodeV3Swap(data, "v1")!;
+  assert.strictEqual(s.fee, 500);
+  assert.strictEqual(s.amountIn.toString(), "5");
+});
+
+test("decodeV3Swap: unwraps multicall to find exactInputSingle", () => {
+  const inner = v2.encodeFunctionData("exactInputSingle", [
+    { tokenIn: A, tokenOut: B, fee: 10000, recipient: REC, amountIn: 7, amountOutMinimum: 6, sqrtPriceLimitX96: 0 },
+  ]);
+  const data = v2.encodeFunctionData("multicall(bytes[])", [[inner]]);
+  const s = decodeV3Swap(data, "v2")!;
+  assert.ok(s, "expected decode from multicall");
+  assert.strictEqual(s.fee, 10000);
+  assert.strictEqual(s.amountIn.toString(), "7");
+});
+
+test("decodeV3Swap: exactInput multi-hop takes the first hop", () => {
+  // path = A | 3000 | B | 500 | C
+  const C = "0x" + "dd".repeat(20);
+  const path = ethers.utils.solidityPack(
+    ["address", "uint24", "address", "uint24", "address"],
+    [A, 3000, B, 500, C]
+  );
+  const data = v2.encodeFunctionData("exactInput", [
+    { path, recipient: REC, amountIn: 100, amountOutMinimum: 80 },
+  ]);
+  const s = decodeV3Swap(data, "v2")!;
+  assert.strictEqual(s.method, "exactInput");
+  assert.strictEqual(s.tokenIn, A.toLowerCase());
+  assert.strictEqual(s.tokenOut, B.toLowerCase());
+  assert.strictEqual(s.fee, 3000);
+  assert.strictEqual(s.multiHop, true);
+});
+
+test("decodeV3Swap: exactOutputSingle is not sandwiched (returns null)", () => {
+  const data = v2.encodeFunctionData("exactOutputSingle", [
+    { tokenIn: A, tokenOut: B, fee: 3000, recipient: REC, amountOut: 1000, amountInMaximum: 2000, sqrtPriceLimitX96: 0 },
+  ]);
+  assert.strictEqual(decodeV3Swap(data, "v2"), null);
+});
+
+test("decodeV3Path: parses first hop", () => {
+  const path = ethers.utils.solidityPack(
+    ["address", "uint24", "address"],
+    [A, 3000, B]
+  );
+  const hop = decodeV3Path(path)!;
+  assert.strictEqual(hop.tokenIn, A.toLowerCase());
+  assert.strictEqual(hop.tokenOut, B.toLowerCase());
+  assert.strictEqual(hop.fee, 3000);
+});
+
+test("decodeV3Path: rejects too-short path", () => {
+  assert.strictEqual(decodeV3Path("0x1234"), null);
+});


### PR DESCRIPTION
## Summary

First step toward UniswapV3 coverage — where the DEX volume (and the largest long-term opportunity surface) actually is. This PR adds a **correct V3 detection foundation** alongside the existing V2 pipeline. Sizing + firing are deliberately deferred (see below) so we don't ship subtly-wrong V3 math.

## What's new
- **`src/core/v3/abi.ts`** — minimal ABIs for both router generations (`SwapRouter` and `SwapRouter02`, which differ on the `deadline` field), the V3 factory, pool, and QuoterV2.
- **`src/core/v3/detect.ts`** — `decodeV3Swap` unwraps `multicall(...)` and normalises `exactInputSingle` and `exactInput` (multi-hop → first hop) into one shape; `exactOutput*` and non-swaps return `null`. Pure + **unit-tested (7 cases)**.
- **`src/core/v3/pool.ts`** — `V3PoolReader` resolves pools via the factory and reads `slot0` (sqrtPriceX96/tick) + `liquidity` — the state a stateful sizer will consume.
- **`config`** — V3 routers (router→version), factory, quoter.
- **`mempool`** — V3 routers take the new path; WETH-funded buys are decoded, pool state is read, and the target is surfaced.

## Why sizing/firing are deferred
The natural idea — call the on-chain Quoter per leg — **doesn't work for V3**: the Quoter always quotes against *live* pool state, so it can't compose front→victim→back (which changes state between legs). Correct V3 sizing needs **stateful simulation** — either V3 tick math (`computeSwapStep` + tick crossing) or `eth_callBundle`/state-override simulation. That's the follow-up; this PR lays the correct groundwork (decode + pool state) rather than guessing.

## Verification
- `npm test` → **27/27** (7 new: both router generations, multicall unwrap, multi-hop first hop, exactOutput rejection, path parser).
- `tsc --noEmit` clean; contracts compile.

## Follow-ups
V3 stateful sizer (tick math or bundle simulation) → V3 executor contract → live firing. The V2 path is unchanged and fully functional.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_