### PR TITLE
mev-share pivot: research memo + listen-only backrun edge validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The dataset is JSON (wei-string fields); see `src/backtest/fixtures/sample.json`
 for the schema. `src/backtest/loader.ts` can build a dataset from real mainnet
 flow when pointed at an archive RPC.
 
+# mev-share backrun validator 🛰️
+A **listen-only** probe for the MEV-Share pivot (see `docs/MEV_SHARE_RESEARCH.md`).
+It subscribes to the MEV-Share hint stream and, for hinted swaps that leak pool
+reserves, estimates the cross-venue backrun arbitrage with the existing pool
+math — to measure whether real backrun edge exists before building the live
+path. **It never submits anything.**
+
+```
+npm run mevshare:validate
+```
+
 # tech-stack
 - `Typerscript`
 - `Ethersjs`

--- a/docs/MEV_SHARE_RESEARCH.md
+++ b/docs/MEV_SHARE_RESEARCH.md
@@ -1,0 +1,105 @@
+# MEV-Share / Backrun Pivot — Research & Recommendation
+
+> Companion to `PROFITABILITY_ANALYSIS.md`. Researched June 2026 from primary
+> Flashbots sources + market data. Confidence levels and the one notable source
+> conflict are flagged inline. The MEV space moves monthly — re-verify before
+> committing capital.
+
+## TL;DR
+
+- **Public-mempool sandwiching (the strategy this bot was built for) is a dead
+  end for a new solo searcher.** In 2025 the *entire ecosystem's* net sandwich
+  profit after gas averaged **~$260k/month**, with **~70% captured by one entity
+  (`jaredfromsubway.eth`)** at **~5% margins**. The pie for everyone else is
+  ~$75–80k/month split among established pros.
+- **Backrunning via MEV-Share / MEV Blocker is the better vehicle** — non-toxic
+  (users get refunded), **~zero capital** (flash-loan funded), durable, and where
+  orderflow is consolidating. **But it is also winner-take-most**: inclusion is a
+  sealed-bid auction where you bid away ~80–90% of profit, and the moat is
+  latency/co-location/venue-coverage, not capital. Realistic outcome for a solo
+  bot: occasional niche edge, not a reliable income.
+- **Recommendation:** stop deepening the sandwich path; keep it as a learning
+  artifact in `DRY_RUN`. Run a cheap, listen-only **backrun edge validator** for
+  a few weeks to measure whether any edge actually reaches us before deploying.
+
+## 1. MEV-Share mechanics — *high confidence*
+
+- Live, run by Flashbots; the orderflow engine behind Flashbots Protect.
+- **Backruns only — sandwiching is structurally impossible** ("MEV-Share Nodes
+  only accept backruns"; a searcher cannot be ordered *before* the user).
+- **Default refund = 90% of captured MEV to the user**; searchers compete for the
+  rest.
+- **BuilderNet** (Nov 2024; Flashbots + Beaverbuild + Nethermind) is a separate
+  *downstream* block-builder layer — it did **not** replace MEV-Share.
+- Sources: https://docs.flashbots.net/flashbots-mev-share/introduction ·
+  https://buildernet.org/blog/introducing-buildernet
+
+## 2. Searcher API / on-ramp — *high confidence*
+
+- Official SDK **`@flashbots/mev-share-client` (TS)**, v0.7.13 — stable but **last
+  released May 2024** (low release velocity; not deprecated). Rust path
+  (`paradigmxyz/mev-share-rs` + Artemis) is more actively maintained.
+- **Hint stream:** SSE at `https://mev-share.flashbots.net`; event shape
+  `{ hash, logs?, txs:[{ to?, functionSelector?, callData? }] }` — fields present
+  per the user's chosen privacy level.
+- **Submit:** `mev_sendBundle` with
+  `body:[{ hash: userTx }, { tx: signedBackrun, canRevert: false }]`.
+- **Templates:** official `example.backrun` and the `simple-blind-arbitrage`
+  flash-loan tutorial (open-source contract + bot).
+- Sources: https://github.com/flashbots/mev-share/blob/main/specs/events/v0.1.md ·
+  https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md ·
+  https://docs.flashbots.net/flashbots-mev-share/searchers/tutorials/flash-loan-arbitrage/simple-blind-arbitrage
+
+## 3. Orderflow-auction landscape — *high confidence*
+
+- **MEV Blocker** (CoW DAO): also **90/10** to users; **2M+ users, ~4,000 ETH
+  rebated**; generally the **highest rebates** and largest searcher backrun venue.
+- Four main protect-RPC / OFA venues: **MEV Blocker, Flashbots Protect, Blink,
+  Merkle**. Orderflow is clearly consolidating into these private channels.
+- Sources: https://cow.fi/learn/what-does-an-mev-blocker-do ·
+  https://cow.fi/learn/mev-blockers-explained-how-they-protect-users
+
+## 4. Profitability reality — *medium-high confidence*
+
+- **Sandwiching:** ecosystem-wide net profit ~$260k/month (2025); gross extraction
+  fell ~$10M → ~$2.5M/month (late-2024 → Oct-2025); ~5% margins; ~70% to Jared.
+- **Backrun arbitrage:** sealed-bid inclusion auction — winning means bidding
+  ~80–90% of profit as the tip; "obvious arbs are instantly captured by
+  sophisticated bots." Moat = latency, co-location, venue coverage, builder
+  relationships. **Capital ≈ near-zero** (flash-loan funded).
+- **Source conflict (flagged):** EigenPhi data shows sharp *value* decline; another
+  analysis argues attack *count* stayed high (60–90k/month) with "no meaningful
+  decline." Reconciliation: **volume steady, value & margins compressed** — a
+  saturated, professionalized market.
+- Sources: https://www.tradingview.com/news/cointelegraph:fa12ba092094b:0-exclusive-data-from-eigenphi-reveals-that-sandwich-attacks-on-ethereum-have-waned/ ·
+  https://writings.flashbots.net/blind-arbitrage-fhe ·
+  https://academy.extropy.io/pages/articles/mev-crosschain-analysis-2025.html ·
+  https://www.bitget.com/news/detail/12560604213767
+
+## 5. Recommendation & minimum-viable path
+
+**Do:**
+1. Stop investing in the sandwich path (shelve the V3 sizer/firing). Keep the
+   finished bot in `DRY_RUN` as a learning artifact.
+2. Run a **listen-only backrun edge validator** (this repo's `mevshare:validate`):
+   subscribe to the MEV-Share SSE stream, and for hinted swaps on pools we cover,
+   estimate the cross-venue arbitrage with our existing pool math. Measure edge
+   for weeks before deploying any capital (which can be ~zero via flash loans).
+3. Only if edge appears: fork `simple-blind-arbitrage` as the executor and submit
+   via `mev_sendBundle`; broaden venue coverage (more V2 pools, V3, later Curve)
+   since hit-rate scales with coverage; also point at MEV Blocker (highest volume).
+
+**Reuse from this codebase:** pool readers, V2 math, decoding, bundle plumbing,
+`profit.ts`, backtest harness. **Shelve:** optimal-frontrun + sandwich executor.
+
+**Be clear-eyed:** backrunning is the *right* direction, but it's competitive and
+latency-bound. For a solo dev the honest expected value is *learning + optionality
++ a small chance of niche edge*, not a business. The validator is how you find out
+cheaply.
+
+## Caveats / least-verified
+
+- Per-searcher backrun profitability is inferred from competition dynamics, not a
+  clean dataset — treat §4's backrun half as directional.
+- The TS SDK's low release velocity (May 2024) is worth confirming vs the Rust
+  path before building the live executor.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "compile:contracts": "node scripts/compile.js",
     "backtest": "ts-node src/backtest/cli.ts",
+    "mevshare:validate": "ts-node src/mevshare/validate.ts",
     "start": "ts-node-dev  src/index.ts"
   },
   "keywords": [],

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -73,4 +73,17 @@ export const config = {
   // Optional token allow/deny lists (comma-separated addresses).
   TOKEN_ALLOWLIST: parseAddressList(process.env.TOKEN_ALLOWLIST),
   TOKEN_DENYLIST: parseAddressList(process.env.TOKEN_DENYLIST),
+
+  // --- MEV-Share backrun edge validator (listen-only) ------------------------
+  MEVSHARE_STREAM_URL:
+    process.env.MEVSHARE_STREAM_URL ?? "https://mev-share.flashbots.net",
+  // Cap (wei) on the arb cycle size used by the optimal-input search.
+  ARB_MAX_IN_WEI: ethersParseEther(process.env.ARB_MAX_IN_ETH ?? "50"),
+  // Only log backrun candidates whose gross WETH profit clears this floor.
+  ARB_MIN_PROFIT_WEI: ethersParseEther(process.env.ARB_MIN_PROFIT_ETH ?? "0.005"),
+  // V2-compatible venues compared for cross-pool arbitrage (name -> factory).
+  V2_VENUES: [
+    { name: "uniswapv2", factory: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f" },
+    { name: "sushiswap", factory: "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac" },
+  ],
 };

--- a/src/mevshare/arb.ts
+++ b/src/mevshare/arb.ts
@@ -1,0 +1,99 @@
+import { BigNumber } from "ethers";
+import { getAmountOut } from "../core/poolMath";
+
+/**
+ * Cross-venue backrun arbitrage.
+ *
+ * When a user's swap moves the price of a token on one venue, the same pair on
+ * another venue is now mispriced. The atomic backrun is: borrow WETH, buy the
+ * token where it's cheap, sell it where it's dear, repay — keeping the spread.
+ * This is the core estimator for the listen-only edge validator (and, later, the
+ * live backrun executor).
+ *
+ * Both pools are modelled as UniswapV2 constant-product (0.30% fee). The profit
+ * curve in the input amount is unimodal, so we ternary-search it — the same
+ * approach (and reasoning) as the sandwich optimal-input search.
+ */
+export interface Pool {
+  /** WETH-side reserve. */
+  reserveWeth: BigNumber;
+  /** Token-side reserve. */
+  reserveToken: BigNumber;
+}
+
+export interface ArbQuote {
+  /** WETH put in at the start of the cycle. */
+  amountIn: BigNumber;
+  /** "buyOnA" => buy token on A, sell on B; "buyOnB" => the reverse. */
+  direction: "buyOnA" | "buyOnB";
+  /** WETH profit after both swaps (gross, pre-gas/bribe). */
+  profit: BigNumber;
+}
+
+const ZERO = BigNumber.from(0);
+
+/** WETH out from cycling `amountIn` WETH: buy token on `buy`, sell it on `sell`. */
+function cycleProfit(amountIn: BigNumber, buy: Pool, sell: Pool): BigNumber {
+  if (amountIn.lte(0)) return ZERO;
+  // WETH -> token on `buy`
+  const tokenOut = getAmountOut(amountIn, buy.reserveWeth, buy.reserveToken);
+  if (tokenOut.lte(0)) return ZERO;
+  // token -> WETH on `sell`
+  const wethOut = getAmountOut(tokenOut, sell.reserveToken, sell.reserveWeth);
+  return wethOut.sub(amountIn);
+}
+
+/** Ternary-search the unimodal profit curve for the best input in [0, hi]. */
+function bestInput(
+  buy: Pool,
+  sell: Pool,
+  hi: BigNumber
+): { amountIn: BigNumber; profit: BigNumber } {
+  let lo = ZERO;
+  let h = hi;
+  while (h.sub(lo).gt(2)) {
+    const third = h.sub(lo).div(3);
+    const m1 = lo.add(third);
+    const m2 = h.sub(third);
+    if (cycleProfit(m1, buy, sell).lt(cycleProfit(m2, buy, sell))) {
+      lo = m1;
+    } else {
+      h = m2;
+    }
+  }
+  let best = lo;
+  let bestProfit = cycleProfit(lo, buy, sell);
+  for (let c = lo.add(1); c.lte(h); c = c.add(1)) {
+    const p = cycleProfit(c, buy, sell);
+    if (p.gt(bestProfit)) {
+      bestProfit = p;
+      best = c;
+    }
+  }
+  return { amountIn: best, profit: bestProfit };
+}
+
+/**
+ * Best WETH-funded arbitrage between two pools for the same pair.
+ *
+ * `maxIn` caps the cycle size (an upper bound for the search; for flash-loan
+ * funded backruns this is a notional/liquidity cap rather than owned capital).
+ * Returns null if neither direction is profitable.
+ */
+export function optimalCrossPoolArb(
+  poolA: Pool,
+  poolB: Pool,
+  maxIn: BigNumber
+): ArbQuote | null {
+  if (maxIn.lte(0)) return null;
+
+  const ab = bestInput(poolA, poolB, maxIn); // buy on A, sell on B
+  const ba = bestInput(poolB, poolA, maxIn); // buy on B, sell on A
+
+  if (ab.profit.lte(0) && ba.profit.lte(0)) return null;
+
+  if (ab.profit.gte(ba.profit)) {
+    return { amountIn: ab.amountIn, direction: "buyOnA", profit: ab.profit };
+  }
+  return { amountIn: ba.amountIn, direction: "buyOnB", profit: ba.profit };
+}

--- a/src/mevshare/client.ts
+++ b/src/mevshare/client.ts
@@ -1,0 +1,91 @@
+import * as https from "https";
+import { Logging } from "../logging/logging";
+import { HintEvent } from "./hints";
+
+/**
+ * Minimal, listen-only Server-Sent-Events client for the MEV-Share hint stream
+ * (https://mev-share.flashbots.net). Listening is public — no auth is needed to
+ * receive hints; auth only matters when you *submit* bundles, which this
+ * validator never does.
+ *
+ * Uses Node's built-in https to avoid pulling in (and version-pinning) the
+ * MEV-Share SDK for what is a one-way read. Auto-reconnects with capped backoff.
+ */
+export class MevShareStream {
+  private _buf = "";
+  private _stopped = false;
+  private _delay = 1_000;
+  private readonly _maxDelay = 30_000;
+
+  constructor(
+    private readonly url: string,
+    private readonly onEvent: (e: HintEvent) => void
+  ) {}
+
+  start() {
+    this._stopped = false;
+    this.connect();
+  }
+
+  stop() {
+    this._stopped = true;
+  }
+
+  private connect() {
+    const req = https.get(
+      this.url,
+      { headers: { Accept: "text/event-stream" } },
+      (res) => {
+        if (res.statusCode !== 200) {
+          Logging.logError(`mev-share stream HTTP ${res.statusCode}`);
+          res.resume();
+          this.scheduleReconnect();
+          return;
+        }
+        Logging.logSuccess("mev-share stream connected");
+        this._delay = 1_000;
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => this.onChunk(chunk));
+        res.on("end", () => this.scheduleReconnect());
+        res.on("error", () => this.scheduleReconnect());
+      }
+    );
+    req.on("error", (err) => {
+      Logging.logError(err);
+      this.scheduleReconnect();
+    });
+  }
+
+  private onChunk(chunk: string) {
+    this._buf += chunk;
+    let idx: number;
+    // SSE events are separated by a blank line.
+    while ((idx = this._buf.indexOf("\n\n")) >= 0) {
+      const block = this._buf.slice(0, idx);
+      this._buf = this._buf.slice(idx + 2);
+      this.handleBlock(block);
+    }
+  }
+
+  private handleBlock(block: string) {
+    const data = block
+      .split("\n")
+      .filter((l) => l.startsWith("data:"))
+      .map((l) => l.slice(5).trim())
+      .join("");
+    if (!data || data === ":ping") return;
+    try {
+      this.onEvent(JSON.parse(data) as HintEvent);
+    } catch {
+      // keep-alives / non-JSON frames
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this._stopped) return;
+    const delay = this._delay;
+    this._delay = Math.min(this._delay * 2, this._maxDelay);
+    Logging.logWarn(`mev-share stream dropped; reconnecting in ${delay}ms`);
+    setTimeout(() => this.connect(), delay);
+  }
+}

--- a/src/mevshare/hints.ts
+++ b/src/mevshare/hints.ts
@@ -1,0 +1,66 @@
+import { BigNumber, ethers } from "ethers";
+import { UniswapV2PairABI } from "../abi";
+
+/**
+ * Parse a MEV-Share hint event into the bits useful for backrun estimation.
+ *
+ * Hint events only carry what the user chose to share. The most actionable hint
+ * for us is a `Sync` log from a UniswapV2 pair: it leaks the pool address and its
+ * *post-swap* reserves directly, which is exactly the state we need to price a
+ * cross-venue backrun. We also surface touched `to`/selector for routing.
+ *
+ * Event shape (Flashbots mev-share specs/events/v0.1):
+ *   { hash, logs?: {address,topics,data}[], txs?: {to?,functionSelector?,callData?}[] }
+ */
+export interface HintLog {
+  address: string;
+  topics: string[];
+  data: string;
+}
+export interface HintEvent {
+  hash: string;
+  logs?: HintLog[];
+  txs?: { to?: string; functionSelector?: string; callData?: string }[];
+}
+
+export interface SyncHint {
+  /** The pair contract that emitted Sync. */
+  pool: string;
+  reserve0: BigNumber;
+  reserve1: BigNumber;
+}
+
+export interface ParsedHint {
+  hash: string;
+  touched: { to?: string; functionSelector?: string }[];
+  /** Decoded UniswapV2 Sync logs (post-swap reserves), if shared. */
+  syncs: SyncHint[];
+}
+
+const PAIR_IFACE = new ethers.utils.Interface(UniswapV2PairABI);
+
+export function parseHint(event: HintEvent): ParsedHint {
+  const touched = (event.txs ?? []).map((t) => ({
+    to: t.to?.toLowerCase(),
+    functionSelector: t.functionSelector,
+  }));
+
+  const syncs: SyncHint[] = [];
+  for (const log of event.logs ?? []) {
+    let parsed: ethers.utils.LogDescription;
+    try {
+      parsed = PAIR_IFACE.parseLog({ topics: log.topics, data: log.data });
+    } catch {
+      continue; // not a pair event we recognise
+    }
+    if (parsed.name === "Sync") {
+      syncs.push({
+        pool: log.address.toLowerCase(),
+        reserve0: parsed.args.reserve0,
+        reserve1: parsed.args.reserve1,
+      });
+    }
+  }
+
+  return { hash: event.hash, touched, syncs };
+}

--- a/src/mevshare/validate.ts
+++ b/src/mevshare/validate.ts
@@ -1,0 +1,6 @@
+import { BackrunValidator } from "./validator";
+
+// Entry point: `npm run mevshare:validate`
+// Listen-only — subscribes to the MEV-Share hint stream and logs estimated
+// cross-venue backrun arbitrage. Submits nothing. See docs/MEV_SHARE_RESEARCH.md.
+new BackrunValidator().start();

--- a/src/mevshare/validator.ts
+++ b/src/mevshare/validator.ts
@@ -1,0 +1,110 @@
+import { BigNumber, ethers } from "ethers";
+import { config } from "../config/config";
+import { Logging } from "../logging/logging";
+import { MevShareStream } from "./client";
+import { parseHint, HintEvent, SyncHint } from "./hints";
+import { MultiVenueV2 } from "./venues";
+import { optimalCrossPoolArb, Pool } from "./arb";
+
+/**
+ * Listen-only MEV-Share backrun edge validator (Phase A of the pivot — see
+ * docs/MEV_SHARE_RESEARCH.md).
+ *
+ * It subscribes to the MEV-Share hint stream and, whenever a hint leaks a
+ * UniswapV2 `Sync` (post-swap reserves for a pool), it looks up the same pair on
+ * the other configured venues and estimates the cross-venue backrun arbitrage
+ * with our existing pool math. It NEVER submits anything — its only job is to
+ * measure whether real backrun edge reaches us before we build the live path.
+ */
+export class BackrunValidator {
+  private _venues: MultiVenueV2;
+  private _stream: MevShareStream;
+  private _weth = config.WETH.toLowerCase();
+
+  // Running tally so a session prints a simple edge summary.
+  private _hints = 0;
+  private _syncs = 0;
+  private _candidates = 0;
+  private _bestProfit = BigNumber.from(0);
+
+  constructor() {
+    this._venues = new MultiVenueV2();
+    this._stream = new MevShareStream(config.MEVSHARE_STREAM_URL, (e) =>
+      this.onEvent(e)
+    );
+  }
+
+  start() {
+    Logging.logInfo(
+      `MEV-Share backrun validator (listen-only) -> ${config.MEVSHARE_STREAM_URL}`
+    );
+    this._stream.start();
+  }
+
+  private onEvent = async (event: HintEvent) => {
+    this._hints++;
+    const parsed = parseHint(event);
+    for (const sync of parsed.syncs) {
+      this._syncs++;
+      try {
+        await this.evaluateSync(sync, parsed.hash);
+      } catch (error) {
+        Logging.logError(error);
+      }
+    }
+  };
+
+  private async evaluateSync(sync: SyncHint, hash: string) {
+    // Identify the pair behind the leaked pool and orient to WETH.
+    const { token0, token1 } = await this._venues.poolTokens(sync.pool);
+    let token: string;
+    let poolFromHint: Pool;
+    if (token0 === this._weth) {
+      token = token1;
+      poolFromHint = { reserveWeth: sync.reserve0, reserveToken: sync.reserve1 };
+    } else if (token1 === this._weth) {
+      token = token0;
+      poolFromHint = { reserveWeth: sync.reserve1, reserveToken: sync.reserve0 };
+    } else {
+      return; // not a WETH pair (out of scope for this first cut)
+    }
+
+    // Same pair across venues; use the fresh hint reserves for the leaked pool.
+    const venues = await this._venues.reservesAcrossVenues(this._weth, token);
+    const pools: Pool[] = venues.map((v) =>
+      v.pool === sync.pool
+        ? poolFromHint
+        : { reserveWeth: v.reserveWeth, reserveToken: v.reserveToken }
+    );
+    if (!venues.some((v) => v.pool === sync.pool)) pools.push(poolFromHint);
+    if (pools.length < 2) return; // need two venues to arb
+
+    // Evaluate every venue pairing; keep the best.
+    let best = null as ReturnType<typeof optimalCrossPoolArb>;
+    for (let i = 0; i < pools.length; i++) {
+      for (let j = i + 1; j < pools.length; j++) {
+        const q = optimalCrossPoolArb(pools[i], pools[j], config.ARB_MAX_IN_WEI);
+        if (q && (!best || q.profit.gt(best.profit))) best = q;
+      }
+    }
+
+    if (!best || best.profit.lt(config.ARB_MIN_PROFIT_WEI)) return;
+
+    this._candidates++;
+    if (best.profit.gt(this._bestProfit)) this._bestProfit = best.profit;
+
+    Logging.logSuccess(`backrun arb candidate (${hash})`);
+    console.log({
+      token,
+      venues: venues.map((v) => v.venue),
+      amountInWeth: ethers.utils.formatEther(best.amountIn),
+      grossProfitWeth: ethers.utils.formatEther(best.profit),
+      sessionTotals: {
+        hints: this._hints,
+        syncs: this._syncs,
+        candidates: this._candidates,
+        bestProfitWeth: ethers.utils.formatEther(this._bestProfit),
+      },
+    });
+  }
+}

--- a/src/mevshare/venues.ts
+++ b/src/mevshare/venues.ts
@@ -1,0 +1,96 @@
+import { BigNumber, ethers, providers } from "ethers";
+import { config } from "../config/config";
+import { UniswapV2PairABI } from "../abi";
+
+const FACTORY_ABI = [
+  "function getPair(address tokenA, address tokenB) view returns (address)",
+];
+
+export interface VenueReserves {
+  venue: string;
+  pool: string;
+  reserveWeth: BigNumber;
+  reserveToken: BigNumber;
+}
+
+/**
+ * Reads the same token pair across several UniswapV2-compatible venues so the
+ * backrun validator can spot cross-venue price gaps. Pair addresses and pool
+ * token ordering are cached; reserves are read fresh (the validator acts on a
+ * just-emitted swap, so staleness must be low).
+ */
+export class MultiVenueV2 {
+  private _provider: providers.JsonRpcProvider;
+  private _factories: { name: string; contract: ethers.Contract }[];
+  private _pairCache = new Map<string, string | null>();
+  private _tokenCache = new Map<string, { token0: string; token1: string }>();
+
+  constructor(
+    rpcUrl: string = config.RPC_URL,
+    venues: { name: string; factory: string }[] = config.V2_VENUES
+  ) {
+    this._provider = new providers.JsonRpcProvider(rpcUrl);
+    this._factories = venues.map((v) => ({
+      name: v.name,
+      contract: new ethers.Contract(v.factory, FACTORY_ABI, this._provider),
+    }));
+  }
+
+  /** token0/token1 of a pool (cached). */
+  async poolTokens(pool: string): Promise<{ token0: string; token1: string }> {
+    const key = pool.toLowerCase();
+    const cached = this._tokenCache.get(key);
+    if (cached) return cached;
+    const c = new ethers.Contract(pool, UniswapV2PairABI, this._provider);
+    const [token0, token1] = await Promise.all([c.token0(), c.token1()]);
+    const entry = {
+      token0: (token0 as string).toLowerCase(),
+      token1: (token1 as string).toLowerCase(),
+    };
+    this._tokenCache.set(key, entry);
+    return entry;
+  }
+
+  private async pairAddress(
+    venue: ethers.Contract,
+    a: string,
+    b: string
+  ): Promise<string | null> {
+    const key = venue.address + ":" + [a, b].sort().join(":");
+    if (this._pairCache.has(key)) return this._pairCache.get(key)!;
+    const pair: string = await venue.getPair(a, b);
+    const resolved =
+      !pair || pair === ethers.constants.AddressZero ? null : pair;
+    this._pairCache.set(key, resolved);
+    return resolved;
+  }
+
+  /** Reserves of (weth, token) on every venue that lists the pair. */
+  async reservesAcrossVenues(
+    weth: string,
+    token: string
+  ): Promise<VenueReserves[]> {
+    const out: VenueReserves[] = [];
+    for (const f of this._factories) {
+      const pool = await this.pairAddress(f.contract, weth, token);
+      if (!pool) continue;
+      try {
+        const c = new ethers.Contract(pool, UniswapV2PairABI, this._provider);
+        const [reserves, token0] = await Promise.all([
+          c.getReserves(),
+          c.token0(),
+        ]);
+        const wethIsToken0 = (token0 as string).toLowerCase() === weth.toLowerCase();
+        out.push({
+          venue: f.name,
+          pool: pool.toLowerCase(),
+          reserveWeth: wethIsToken0 ? reserves[0] : reserves[1],
+          reserveToken: wethIsToken0 ? reserves[1] : reserves[0],
+        });
+      } catch {
+        // skip unreadable pool
+      }
+    }
+    return out;
+  }
+}

--- a/tests/arb.test.ts
+++ b/tests/arb.test.ts
@@ -1,0 +1,56 @@
+import assert from "assert";
+import { BigNumber, utils } from "ethers";
+import { optimalCrossPoolArb, Pool } from "../src/mevshare/arb";
+import { getAmountOut } from "../src/core/poolMath";
+import { test } from "./harness";
+
+const eth = (v: string) => utils.parseEther(v);
+
+test("optimalCrossPoolArb: no profit when pools are identical", () => {
+  const p: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  assert.strictEqual(optimalCrossPoolArb(p, { ...p }, eth("50")), null);
+});
+
+test("optimalCrossPoolArb: finds profit when one pool is mispriced", () => {
+  // Pool A: token is cheaper (more token per WETH). Pool B: dearer.
+  const a: Pool = { reserveWeth: eth("100"), reserveToken: eth("220000") };
+  const b: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  const q = optimalCrossPoolArb(a, b, eth("50"))!;
+  assert.ok(q, "expected an arb");
+  assert.ok(q.profit.gt(0), `expected positive profit, got ${q.profit}`);
+  // Token is cheaper on A => buy on A, sell on B.
+  assert.strictEqual(q.direction, "buyOnA");
+});
+
+test("optimalCrossPoolArb: direction flips when the dear/cheap pools swap", () => {
+  const a: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  const b: Pool = { reserveWeth: eth("100"), reserveToken: eth("220000") };
+  const q = optimalCrossPoolArb(a, b, eth("50"))!;
+  assert.strictEqual(q.direction, "buyOnB");
+});
+
+test("optimalCrossPoolArb: reported profit reproduces via the two swaps", () => {
+  const a: Pool = { reserveWeth: eth("80"), reserveToken: eth("200000") };
+  const b: Pool = { reserveWeth: eth("120"), reserveToken: eth("200000") };
+  const q = optimalCrossPoolArb(a, b, eth("50"))!;
+  assert.ok(q, "expected an arb");
+  // Recompute the cycle for the chosen direction and amount.
+  const [buy, sell] = q.direction === "buyOnA" ? [a, b] : [b, a];
+  const tok = getAmountOut(q.amountIn, buy.reserveWeth, buy.reserveToken);
+  const wethBack = getAmountOut(tok, sell.reserveToken, sell.reserveWeth);
+  assert.strictEqual(wethBack.sub(q.amountIn).toString(), q.profit.toString());
+});
+
+test("optimalCrossPoolArb: profit is not beaten by nearby input sizes", () => {
+  const a: Pool = { reserveWeth: eth("80"), reserveToken: eth("210000") };
+  const b: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  const q = optimalCrossPoolArb(a, b, eth("50"))!;
+  const [buy, sell] = q.direction === "buyOnA" ? [a, b] : [b, a];
+  const cycle = (amt: BigNumber) => {
+    const tok = getAmountOut(amt, buy.reserveWeth, buy.reserveToken);
+    return getAmountOut(tok, sell.reserveToken, sell.reserveWeth).sub(amt);
+  };
+  const step = q.amountIn.div(50).add(1);
+  assert.ok(q.profit.gte(cycle(q.amountIn.sub(step))), "smaller input beat optimum");
+  assert.ok(q.profit.gte(cycle(q.amountIn.add(step))), "larger input beat optimum");
+});

--- a/tests/hints.test.ts
+++ b/tests/hints.test.ts
@@ -1,0 +1,45 @@
+import assert from "assert";
+import { ethers, BigNumberish } from "ethers";
+import { UniswapV2PairABI } from "../src/abi";
+import { parseHint, HintEvent } from "../src/mevshare/hints";
+import { test } from "./harness";
+
+const iface = new ethers.utils.Interface(UniswapV2PairABI);
+const POOL = "0x" + "ab".repeat(20);
+const ROUTER = "0x" + "cd".repeat(20);
+
+function syncLog(pool: string, r0: BigNumberish, r1: BigNumberish) {
+  const frag = iface.getEvent("Sync");
+  const { data, topics } = iface.encodeEventLog(frag, [r0, r1]);
+  return { address: pool, topics, data };
+}
+
+test("parseHint: decodes a Sync log into pool + reserves", () => {
+  const event: HintEvent = {
+    hash: "0xdeadbeef",
+    logs: [syncLog(POOL, "1000", "2000")],
+    txs: [{ to: ROUTER, functionSelector: "0x38ed1739" }],
+  };
+  const parsed = parseHint(event);
+  assert.strictEqual(parsed.hash, "0xdeadbeef");
+  assert.strictEqual(parsed.syncs.length, 1);
+  assert.strictEqual(parsed.syncs[0].pool, POOL.toLowerCase());
+  assert.strictEqual(parsed.syncs[0].reserve0.toString(), "1000");
+  assert.strictEqual(parsed.syncs[0].reserve1.toString(), "2000");
+  assert.strictEqual(parsed.touched[0].to, ROUTER.toLowerCase());
+  assert.strictEqual(parsed.touched[0].functionSelector, "0x38ed1739");
+});
+
+test("parseHint: no logs yields no syncs but still surfaces touched txs", () => {
+  const parsed = parseHint({ hash: "0x1", txs: [{ to: ROUTER }] });
+  assert.strictEqual(parsed.syncs.length, 0);
+  assert.strictEqual(parsed.touched[0].to, ROUTER.toLowerCase());
+});
+
+test("parseHint: ignores logs that aren't recognised pair events", () => {
+  const parsed = parseHint({
+    hash: "0x2",
+    logs: [{ address: POOL, topics: ["0x" + "00".repeat(32)], data: "0x" }],
+  });
+  assert.strictEqual(parsed.syncs.length, 0);
+});

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -6,6 +6,8 @@ import "./profit.test";
 import "./safety.test";
 import "./backtest.test";
 import "./v3detect.test";
+import "./arb.test";
+import "./hints.test";
 import { summary } from "./harness";
 
 summary();


### PR DESCRIPTION
## Summary

Two things, per the decision to weigh the MEV-Share pivot and validate it cheaply:

1. **`docs/MEV_SHARE_RESEARCH.md`** — cited research + recommendation (researched June 2026, confidence levels + one source conflict flagged).
2. **A listen-only backrun edge validator** — measures whether real backrun edge reaches us *before* any capital or live-execution work.

## The research, in one breath
- **Public-mempool sandwiching is a dead end for a new solo searcher:** 2025 ecosystem-wide net sandwich profit ≈ **$260k/month**, **~70% captured by one entity** (`jaredfromsubway.eth`), ~5% margins.
- **MEV-Share is backrun-only**, **90% refund to users**, healthy searcher API (`@flashbots/mev-share-client`, SSE hint stream, `mev_sendBundle`, `simple-blind-arbitrage` template). **MEV Blocker** is the other big OFA (also 90/10, 2M+ users).
- **Backrunning is the better vehicle** (non-toxic, ~zero capital via flash loans, durable) **but winner-take-most** — inclusion is a sealed-bid auction (~80–90% of profit bid away); the moat is latency/co-location/venue coverage.
- **Recommendation:** stop deepening the sandwich path; run the validator for a few weeks to see if edge reaches us.

## The validator (Phase A)
Subscribes to the MEV-Share hint stream; when a hint leaks a UniswapV2 `Sync` (post-swap reserves), it prices the cross-venue backrun arb (Uniswap vs Sushiswap) with our existing pool math and logs candidates + a session edge tally. **It submits nothing.**

- `mevshare/arb.ts` — optimal cross-pool arbitrage (ternary search, reuses `getAmountOut`). **Pure, 5 tests.**
- `mevshare/hints.ts` — parse hint events; decode `Sync` logs → pool + reserves. **Pure, 3 tests.**
- `mevshare/venues.ts` — same pair across V2 venues.
- `mevshare/client.ts` — minimal listen-only SSE client (Node `https`, auto-reconnect; **no new deps**, no auth — listening is public).
- `mevshare/validator.ts` + `validate.ts` → `npm run mevshare:validate`.

## Verification
- `npm test` → **35/35** (8 new: arb + hints); `tsc --noEmit` clean; contract compiles.
- No new dependencies; live execution intentionally not built (that's only worth doing if the validator shows edge).

## Honest caveat
Backrunning is the right *direction*, not a guaranteed income — for a solo bot the realistic expected value is learning + optionality + a small chance of niche edge. The validator is how you find out at near-zero cost.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_