### PR TITLE
notify: Telegram alerts for opportunities + backtests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ FEE_TOLERANCE_BPS=100
 # Optional comma-separated token allow/deny lists.
 TOKEN_ALLOWLIST=
 TOKEN_DENYLIST=
+
+# --- Telegram notifications ---
+# Create a bot with @BotFather to get the token. NEVER commit real values.
+TELEGRAM_BOT_TOKEN=
+# Run `npm run telegram:chatid` (after messaging your bot) to discover this.
+TELEGRAM_CHAT_ID=

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "compile:contracts": "node scripts/compile.js",
     "backtest": "ts-node src/backtest/cli.ts",
     "mevshare:validate": "ts-node src/mevshare/validate.ts",
+    "telegram:chatid": "ts-node src/notify/chatid.ts",
+    "telegram:test": "ts-node src/notify/test.ts",
     "start": "ts-node-dev  src/index.ts"
   },
   "keywords": [],

--- a/src/backtest/cli.ts
+++ b/src/backtest/cli.ts
@@ -3,6 +3,8 @@ import * as path from "path";
 import { BigNumber } from "ethers";
 import { runBacktest, BacktestScenario, BacktestParams } from "./engine";
 import { formatReport } from "./report";
+import { telegram } from "../notify/telegram";
+import { formatBacktestSummary } from "../notify/format";
 
 /**
  * Run a backtest from a JSON fixture of historical scenarios.
@@ -49,7 +51,7 @@ function load(file: string): { scenarios: BacktestScenario[]; params: BacktestPa
   return { scenarios, params };
 }
 
-function main() {
+async function main() {
   const file =
     process.argv[2] ||
     path.join(__dirname, "fixtures", "sample.json");
@@ -60,6 +62,8 @@ function main() {
   const { scenarios, params } = load(file);
   const report = runBacktest(scenarios, params);
   console.log(formatReport(report));
+  // Push the summary to Telegram if configured (no-op otherwise).
+  await telegram.notify(formatBacktestSummary(report));
 }
 
 main();

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -86,4 +86,9 @@ export const config = {
     { name: "uniswapv2", factory: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f" },
     { name: "sushiswap", factory: "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac" },
   ],
+
+  // --- Telegram notifications ------------------------------------------------
+  // Set both in .env. NEVER commit real values (the .env is gitignored).
+  TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
+  TELEGRAM_CHAT_ID: process.env.TELEGRAM_CHAT_ID,
 };

--- a/src/core/mempool.ts
+++ b/src/core/mempool.ts
@@ -14,6 +14,8 @@ import { checkTokenLists } from "./safety";
 import { BundleExecutor, SandwichPlan } from "./bundle";
 import { decodeV3Swap, V3RouterVersion } from "./v3/detect";
 import { v3PoolReader } from "./v3/pool";
+import { telegram } from "../notify/telegram";
+import { formatSandwichAlert } from "../notify/format";
 import { ethers as ethersLib } from "ethers";
 
 /** Reconnect backoff bounds for the websocket provider (ms). */
@@ -272,6 +274,18 @@ class mempool {
       bribeWeth: ethersLib.utils.formatEther(decision.bribe),
       netProfitWeth: ethersLib.utils.formatEther(decision.netProfit),
     });
+
+    // Notify before we execute, so opportunities are visible even in DRY_RUN.
+    await telegram.notify(
+      formatSandwichAlert({
+        hash,
+        token: tokenOut,
+        pair: reserves.pair,
+        quote,
+        decision,
+        dryRun: config.DRY_RUN,
+      })
+    );
 
     // Build, simulate, and (unless DRY_RUN) fire the bundle. Requires a funded
     // signer and a deployed executor; without them we stay in monitor mode.

--- a/src/mevshare/validator.ts
+++ b/src/mevshare/validator.ts
@@ -5,6 +5,8 @@ import { MevShareStream } from "./client";
 import { parseHint, HintEvent, SyncHint } from "./hints";
 import { MultiVenueV2 } from "./venues";
 import { optimalCrossPoolArb, Pool } from "./arb";
+import { telegram } from "../notify/telegram";
+import { formatBackrunAlert } from "../notify/format";
 
 /**
  * Listen-only MEV-Share backrun edge validator (Phase A of the pivot — see
@@ -106,5 +108,14 @@ export class BackrunValidator {
         bestProfitWeth: ethers.utils.formatEther(this._bestProfit),
       },
     });
+
+    await telegram.notify(
+      formatBackrunAlert({
+        hash,
+        token,
+        venues: venues.map((v) => v.venue),
+        quote: best,
+      })
+    );
   }
 }

--- a/src/notify/chatid.ts
+++ b/src/notify/chatid.ts
@@ -1,0 +1,69 @@
+import * as https from "https";
+import { config } from "../config/config";
+
+/**
+ * Discover your Telegram chat id.
+ *
+ *   1. Send any message to your bot in Telegram (or add it to a group and post).
+ *   2. Run: `npm run telegram:chatid`
+ *
+ * It calls getUpdates and prints the chat id(s) seen. Put the value in
+ * TELEGRAM_CHAT_ID in your .env. Requires TELEGRAM_BOT_TOKEN to be set.
+ */
+function main() {
+  const token = config.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error("TELEGRAM_BOT_TOKEN not set in .env");
+    process.exit(1);
+  }
+
+  https
+    .get(`https://api.telegram.org/bot${token}/getUpdates`, (res) => {
+      let data = "";
+      res.setEncoding("utf8");
+      res.on("data", (c: string) => (data += c));
+      res.on("end", () => {
+        let json: any;
+        try {
+          json = JSON.parse(data);
+        } catch {
+          console.error(
+            "Unexpected non-JSON response (network policy/proxy blocking api.telegram.org?):"
+          );
+          console.error("  " + data.slice(0, 200));
+          process.exit(1);
+        }
+        try {
+          if (!json.ok) {
+            console.error("Telegram API error:", json);
+            process.exit(1);
+          }
+          const chats = new Map<string, string>();
+          for (const u of json.result ?? []) {
+            const chat = u.message?.chat ?? u.channel_post?.chat;
+            if (chat) {
+              const label = chat.title ?? chat.username ?? chat.first_name ?? "";
+              chats.set(String(chat.id), `${chat.type} ${label}`.trim());
+            }
+          }
+          if (chats.size === 0) {
+            console.log(
+              "No chats found. Message your bot first, then re-run this."
+            );
+            return;
+          }
+          console.log("Discovered chats (set TELEGRAM_CHAT_ID to one of these):");
+          for (const [id, label] of chats) console.log(`  ${id}  — ${label}`);
+        } catch (err) {
+          console.error("Failed to parse response:", err);
+          process.exit(1);
+        }
+      });
+    })
+    .on("error", (err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+main();

--- a/src/notify/format.ts
+++ b/src/notify/format.ts
@@ -1,0 +1,65 @@
+import { BigNumber, utils } from "ethers";
+import { SandwichQuote } from "../core/poolMath";
+import { ProfitDecision } from "../core/profit";
+import { ArbQuote } from "../mevshare/arb";
+import { BacktestReport } from "../backtest/engine";
+
+/**
+ * Pure formatters for Telegram alerts. Kept separate from the transport so they
+ * can be unit-tested. Output is Telegram Markdown.
+ */
+const eth = (v: BigNumber) => utils.formatEther(v);
+
+/** Alert for a profitable sandwich candidate (sent before we execute). */
+export function formatSandwichAlert(params: {
+  hash: string;
+  token: string;
+  pair: string;
+  quote: SandwichQuote;
+  decision: ProfitDecision;
+  dryRun: boolean;
+}): string {
+  const { hash, token, pair, quote, decision, dryRun } = params;
+  return [
+    `🥪 *Sandwich opportunity*${dryRun ? " _(DRY_RUN)_" : ""}`,
+    `token: \`${token}\``,
+    `pair: \`${pair}\``,
+    `frontrun in: ${eth(quote.frontrunIn)} WETH`,
+    `gross: ${eth(quote.grossProfit)} WETH`,
+    `gas: ${eth(decision.gasCost)} | bribe: ${eth(decision.bribe)} WETH`,
+    `*net: ${eth(decision.netProfit)} WETH*`,
+    `tx: \`${hash}\``,
+  ].join("\n");
+}
+
+/** Alert for a cross-venue backrun arbitrage candidate. */
+export function formatBackrunAlert(params: {
+  hash: string;
+  token: string;
+  venues: string[];
+  quote: ArbQuote;
+}): string {
+  const { hash, token, venues, quote } = params;
+  return [
+    `🛰️ *Backrun arb opportunity*`,
+    `token: \`${token}\``,
+    `venues: ${venues.join(" ↔ ")}`,
+    `direction: ${quote.direction}`,
+    `amount in: ${eth(quote.amountIn)} WETH`,
+    `*gross: ${eth(quote.profit)} WETH*`,
+    `hint: \`${hash}\``,
+  ].join("\n");
+}
+
+/** Summary of a backtest run. */
+export function formatBacktestSummary(r: BacktestReport): string {
+  return [
+    `📊 *Backtest complete*`,
+    `scenarios: ${r.scenarios} | feasible: ${r.feasible} | profitable: ${r.profitable}`,
+    `hit rate: ${(r.hitRate * 100).toFixed(1)}%`,
+    `gross: ${eth(r.grossProfitTotal)} | gas: ${eth(r.gasCostTotal)} WETH`,
+    `bribe: ${eth(r.bribeTotal)} WETH`,
+    `*net total: ${eth(r.netProfitTotal)} WETH*`,
+    `best single: ${eth(r.bestNet)} WETH${r.bestLabel ? ` (${r.bestLabel})` : ""}`,
+  ].join("\n");
+}

--- a/src/notify/telegram.ts
+++ b/src/notify/telegram.ts
@@ -1,0 +1,89 @@
+import * as https from "https";
+import { config } from "../config/config";
+import { Logging } from "../logging/logging";
+
+/**
+ * Telegram notifier.
+ *
+ * Sends alerts via the Telegram Bot API. Configuration comes from env
+ * (TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID) — never hardcode the token. The
+ * transport is injectable so the formatting/enablement logic is unit-testable
+ * without touching the network, and it fails soft (a notification problem must
+ * never crash the bot or block execution decisions).
+ */
+export type SendFn = (token: string, payload: TelegramPayload) => Promise<void>;
+
+export interface TelegramPayload {
+  chat_id: string;
+  text: string;
+  parse_mode?: string;
+  disable_web_page_preview?: boolean;
+}
+
+const httpsSend: SendFn = (token, payload) =>
+  new Promise((resolve) => {
+    const body = JSON.stringify(payload);
+    const req = https.request(
+      `https://api.telegram.org/bot${token}/sendMessage`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        // Drain and resolve regardless of status; log non-2xx for visibility.
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (c: string) => (data += c));
+        res.on("end", () => {
+          if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
+            Logging.logWarn(`telegram sendMessage HTTP ${res.statusCode}: ${data}`);
+          }
+          resolve();
+        });
+      }
+    );
+    req.on("error", (err) => {
+      Logging.logError(err);
+      resolve();
+    });
+    req.write(body);
+    req.end();
+  });
+
+export class TelegramNotifier {
+  constructor(
+    private readonly token: string | undefined = config.TELEGRAM_BOT_TOKEN,
+    private readonly chatId: string | undefined = config.TELEGRAM_CHAT_ID,
+    private readonly send: SendFn = httpsSend
+  ) {}
+
+  /** True only when both token and chat id are configured. */
+  get enabled(): boolean {
+    return !!this.token && !!this.chatId;
+  }
+
+  /**
+   * Send a Markdown message. Returns true if it was dispatched, false if
+   * notifications are disabled (unconfigured). Never throws.
+   */
+  async notify(text: string): Promise<boolean> {
+    if (!this.token || !this.chatId) return false;
+    try {
+      await this.send(this.token, {
+        chat_id: this.chatId,
+        text,
+        parse_mode: "Markdown",
+        disable_web_page_preview: true,
+      });
+      return true;
+    } catch (err) {
+      Logging.logError(err);
+      return false;
+    }
+  }
+}
+
+export const telegram = new TelegramNotifier();

--- a/src/notify/test.ts
+++ b/src/notify/test.ts
@@ -1,0 +1,17 @@
+import { telegram } from "./telegram";
+
+/**
+ * Send a test message to confirm Telegram is wired up.
+ *   npm run telegram:test
+ * Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in .env.
+ */
+(async () => {
+  if (!telegram.enabled) {
+    console.error(
+      "Telegram not configured. Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in .env."
+    );
+    process.exit(1);
+  }
+  const ok = await telegram.notify("✅ *sando-mev* Telegram notifications are wired up.");
+  console.log(ok ? "sent" : "failed to send");
+})();

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,17 +1,27 @@
-// Tiny shared test harness so each test file can register cases and a single
-// runner can aggregate pass/fail across them.
+// Tiny shared test harness. Tests register via `test()` and are executed by
+// `runAll()` so async cases are awaited (a synchronous try/catch would miss
+// rejected promises and silently "pass").
+type TestFn = () => void | Promise<void>;
+
+const cases: { name: string; fn: TestFn }[] = [];
 let passed = 0;
 let failed = 0;
 
-export function test(name: string, fn: () => void) {
-  try {
-    fn();
-    passed++;
-    console.log(`  ok  ${name}`);
-  } catch (err) {
-    failed++;
-    console.error(`FAIL  ${name}`);
-    console.error(`      ${(err as Error).message}`);
+export function test(name: string, fn: TestFn) {
+  cases.push({ name, fn });
+}
+
+export async function runAll(): Promise<void> {
+  for (const { name, fn } of cases) {
+    try {
+      await fn();
+      passed++;
+      console.log(`  ok  ${name}`);
+    } catch (err) {
+      failed++;
+      console.error(`FAIL  ${name}`);
+      console.error(`      ${(err as Error).message}`);
+    }
   }
 }
 

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -1,0 +1,98 @@
+import assert from "assert";
+import { BigNumber, utils } from "ethers";
+import { TelegramNotifier, TelegramPayload } from "../src/notify/telegram";
+import {
+  formatSandwichAlert,
+  formatBackrunAlert,
+  formatBacktestSummary,
+} from "../src/notify/format";
+import { test } from "./harness";
+
+const eth = (v: string) => utils.parseEther(v);
+
+test("TelegramNotifier: disabled (no-op) when unconfigured", async () => {
+  let called = false;
+  const n = new TelegramNotifier(undefined, undefined, async () => {
+    called = true;
+  });
+  assert.strictEqual(n.enabled, false);
+  assert.strictEqual(await n.notify("hi"), false);
+  assert.strictEqual(called, false);
+});
+
+test("TelegramNotifier: sends correct payload when configured", async () => {
+  const sent: { token: string; payload: TelegramPayload }[] = [];
+  const n = new TelegramNotifier("TOK", "123", async (token, payload) => {
+    sent.push({ token, payload });
+  });
+  assert.strictEqual(n.enabled, true);
+  assert.strictEqual(await n.notify("hello"), true);
+  assert.strictEqual(sent.length, 1);
+  assert.strictEqual(sent[0].token, "TOK");
+  assert.strictEqual(sent[0].payload.chat_id, "123");
+  assert.strictEqual(sent[0].payload.text, "hello");
+  assert.strictEqual(sent[0].payload.parse_mode, "Markdown");
+});
+
+test("TelegramNotifier: never throws if transport rejects", async () => {
+  const n = new TelegramNotifier("TOK", "123", async () => {
+    throw new Error("network down");
+  });
+  assert.strictEqual(await n.notify("x"), false);
+});
+
+test("formatSandwichAlert: includes net profit and tx hash", () => {
+  const msg = formatSandwichAlert({
+    hash: "0xabc",
+    token: "0xtoken",
+    pair: "0xpair",
+    quote: {
+      frontrunIn: eth("1"),
+      tokensBought: BigNumber.from("5"),
+      victimOut: BigNumber.from("4"),
+      backrunOut: eth("1.1"),
+      grossProfit: eth("0.1"),
+    },
+    decision: {
+      viable: true,
+      gasCost: eth("0.005"),
+      bribe: eth("0.075"),
+      netProfit: eth("0.02"),
+    },
+    dryRun: true,
+  });
+  assert.ok(msg.includes("Sandwich opportunity"));
+  assert.ok(msg.includes("DRY_RUN"));
+  assert.ok(msg.includes("0xabc"));
+  assert.ok(msg.includes("net: 0.02 WETH"));
+});
+
+test("formatBackrunAlert: includes venues and gross profit", () => {
+  const msg = formatBackrunAlert({
+    hash: "0xhint",
+    token: "0xtoken",
+    venues: ["uniswapv2", "sushiswap"],
+    quote: { amountIn: eth("2"), direction: "buyOnA", profit: eth("0.03") },
+  });
+  assert.ok(msg.includes("Backrun arb"));
+  assert.ok(msg.includes("uniswapv2 ↔ sushiswap"));
+  assert.ok(msg.includes("0.03 WETH"));
+});
+
+test("formatBacktestSummary: includes hit rate and net total", () => {
+  const msg = formatBacktestSummary({
+    scenarios: 10,
+    feasible: 6,
+    profitable: 4,
+    hitRate: 0.4,
+    grossProfitTotal: eth("1"),
+    gasCostTotal: eth("0.02"),
+    bribeTotal: eth("0.9"),
+    netProfitTotal: eth("0.08"),
+    bestNet: eth("0.05"),
+    bestLabel: "blk:1",
+  });
+  assert.ok(msg.includes("Backtest complete"));
+  assert.ok(msg.includes("40.0%"));
+  assert.ok(msg.includes("net total: 0.08 WETH"));
+});

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -8,6 +8,7 @@ import "./backtest.test";
 import "./v3detect.test";
 import "./arb.test";
 import "./hints.test";
-import { summary } from "./harness";
+import "./notify.test";
+import { runAll, summary } from "./harness";
 
-summary();
+runAll().then(summary);


### PR DESCRIPTION
## Summary

Adds Telegram notifications across the three opportunity paths, so you get alerted **before** anything executes. Configuration is env-only — the bot token is never hardcoded or committed.

## What it does
- **Sandwich path (`mempool`)** — alerts on a profitable sandwich candidate **before executing** (fires in `DRY_RUN` too, so opportunities are visible without submitting).
- **Backrun validator** — alerts on a cross-venue backrun arb candidate.
- **Backtest CLI** — pushes the run summary to Telegram.

## Implementation
- `notify/telegram.ts` — env-gated notifier (`TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`) with an **injectable transport** (Node `https`, **no new deps**). Fail-soft: a notification problem never throws or blocks an execution decision; no-ops when unconfigured.
- `notify/format.ts` — pure Markdown formatters (sandwich / backrun / backtest). Unit-tested.
- `notify/chatid.ts` → `npm run telegram:chatid` (discover your chat id), `notify/test.ts` → `npm run telegram:test` (send a test message).
- Test harness upgraded to run async cases via `runAll()` so promise rejections are caught.

## Verification
- `npm test` → **41/41** (6 new: notifier enable/disable/throw-safety + 3 formatters); `tsc --noEmit` clean; contract compiles.
- Token-leak scan of tracked files: clean.

## ⚠️ Security — please action
- The bot token was shared in plaintext chat, so **treat it as compromised: revoke/regenerate it in @BotFather and use the new one.** It is **not** in the repo (only `.env`, which is gitignored); `.env.example` has placeholders.
- The sandbox's network policy blocks `api.telegram.org`, so I couldn't run the live send from here — it will work in your environment. To set up: put the (rotated) token in `.env`, message your bot once, run `npm run telegram:chatid` to get `TELEGRAM_CHAT_ID`, then `npm run telegram:test`.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_