### PR TITLE
docs: add "Running locally" guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,60 @@ The goal of this bot is to build an optimized searcher, brick 🧱 by 🧱 .
   - doing math in Typescript
   - calculating next base fee
 
+# running locally 🏃
+### Prerequisites
+- **Node.js 20** + npm.
+- An Ethereum **RPC + WebSocket** endpoint. Two env vars are required or the bot
+  exits on start:
+  - `RPC_URL` — HTTPS JSON-RPC (pool reads, simulation).
+  - `WSS_URL` — WebSocket. The sandwich monitor subscribes to **pending
+    transactions**, so this must be a node/provider that streams them (your own
+    geth/erigon, or e.g. Alchemy's `newPendingTransactions`). The backtester and
+    MEV-Share validator do **not** need a pending-tx feed.
+
+### Install & configure
+```bash
+git clone https://github.com/henrykash/sando-mev.git
+cd sando-mev
+npm ci                 # or: npm install
+cp .env.example .env   # then edit .env
+```
+Minimum `.env` to start (monitoring only):
+```
+RPC_URL=https://<your-rpc>
+WSS_URL=wss://<your-ws-endpoint>
+DRY_RUN=true           # keep true until you have a deployed executor
+```
+Everything else is optional: `PRIVATE_KEY` + `SANDWICH_CONTRACT` (live firing
+only), `FLASHBOTS_AUTH_KEY`, the `TELEGRAM_*` vars, and tuning knobs
+(`MAX_FRONTRUN_ETH`, `MIN_MARGIN_ETH`, …). See `.env.example` for the full list.
+
+### Run modes
+```bash
+# sanity checks (no network)
+npm run typecheck
+npm test
+npm run compile:contracts
+
+npm run backtest             # estimate edge on the sample dataset (no network)
+npm run mevshare:validate    # listen-only backrun validator (needs RPC_URL)
+npm start                    # sandwich monitor (needs pending-tx WSS_URL; DRY_RUN)
+```
+
+### Telegram notifications (optional)
+```bash
+# put TELEGRAM_BOT_TOKEN in .env, then message your bot once
+npm run telegram:chatid      # prints chat id -> set TELEGRAM_CHAT_ID in .env
+npm run telegram:test        # sends a test message
+```
+
+### Going live (only when you mean it)
+Live submission stays off until **all** of: `DRY_RUN=false`, `PRIVATE_KEY` set
+(a funded hot wallet), and `SANDWICH_CONTRACT` set to a deployed executor
+(`contracts/Sandwich.sol`). Until then the bot monitors, simulates, and alerts
+but never submits. Validate edge in monitoring mode first —
+see `docs/PROFITABILITY_ANALYSIS.md` and `docs/MEV_SHARE_RESEARCH.md`.
+
 # backtesting 📊
 Estimate edge before risking capital by replaying historical victim swaps
 through the same optimal-input + net-profit logic the live bot uses:


### PR DESCRIPTION
## Summary

Documents how to run the project locally (the question that keeps coming up). README-only change.

Adds a **Running locally** section covering:
- **Prerequisites** — Node 20, `RPC_URL`/`WSS_URL`, with the note that the sandwich monitor needs a **pending-tx** WSS feed while the backtester/validator don't.
- **Install & configure** — clone, `npm ci`, `.env` minimum.
- **Run modes** — `typecheck`/`test`/`compile:contracts`, `backtest`, `mevshare:validate`, `start`.
- **Telegram setup** — `telegram:chatid` / `telegram:test`.
- **Going live** — the `DRY_RUN=false` + `PRIVATE_KEY` + `SANDWICH_CONTRACT` preconditions, pointing at the analysis docs.

No code changes; CI (typecheck + tests + contract compile) is unaffected.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_