### PR TITLE
notify: startup, heartbeat & connection alerts for npm start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ TOKEN_DENYLIST=
 TELEGRAM_BOT_TOKEN=
 # Run `npm run telegram:chatid` (after messaging your bot) to discover this.
 TELEGRAM_CHAT_ID=
+# Minutes between "still alive" heartbeat messages on npm start (0 disables). Default 30.
+HEARTBEAT_MINUTES=30

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -91,4 +91,6 @@ export const config = {
   // Set both in .env. NEVER commit real values (the .env is gitignored).
   TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
   TELEGRAM_CHAT_ID: process.env.TELEGRAM_CHAT_ID,
+  // Minutes between "still alive" heartbeat messages (0 disables).
+  HEARTBEAT_MINUTES: Number(process.env.HEARTBEAT_MINUTES ?? "30"),
 };

--- a/src/core/mempool.ts
+++ b/src/core/mempool.ts
@@ -15,7 +15,12 @@ import { BundleExecutor, SandwichPlan } from "./bundle";
 import { decodeV3Swap, V3RouterVersion } from "./v3/detect";
 import { v3PoolReader } from "./v3/pool";
 import { telegram } from "../notify/telegram";
-import { formatSandwichAlert } from "../notify/format";
+import {
+  formatSandwichAlert,
+  formatStartup,
+  formatConnection,
+  formatHeartbeat,
+} from "../notify/format";
 import { ethers as ethersLib } from "ethers";
 
 /** Reconnect backoff bounds for the websocket provider (ms). */
@@ -34,6 +39,14 @@ class mempool {
   private _stopped = false;
   private _executor?: BundleExecutor;
 
+  // Status/heartbeat tracking for Telegram visibility.
+  private _startedAt = 0;
+  private _wasConnected = false;
+  private _heartbeatTimer?: ReturnType<typeof setInterval>;
+  private _v2Targets = 0;
+  private _v3Targets = 0;
+  private _profitable = 0;
+
   constructor() {
     this._uniswap = new ethers.utils.Interface(UniswapV2RouterABI);
     // Lower-case the router set once so per-tx comparisons are cheap.
@@ -47,7 +60,27 @@ class mempool {
 
   public mempool = async () => {
     this._stopped = false;
+    this._startedAt = Date.now();
+    telegram.notify(formatStartup(config.DRY_RUN));
+    this.startHeartbeat();
     this.connect();
+  };
+
+  /** Periodic "still alive" Telegram summary so a quiet bot looks healthy. */
+  private startHeartbeat = () => {
+    const minutes = config.HEARTBEAT_MINUTES;
+    if (minutes <= 0 || this._heartbeatTimer) return;
+    this._heartbeatTimer = setInterval(() => {
+      telegram.notify(
+        formatHeartbeat({
+          uptimeMinutes: Math.round((Date.now() - this._startedAt) / 60_000),
+          v2Targets: this._v2Targets,
+          v3Targets: this._v3Targets,
+          profitable: this._profitable,
+          dryRun: config.DRY_RUN,
+        })
+      );
+    }, minutes * 60_000);
   };
 
   /** (Re)create the provider, wire up the pending feed, and handle drops. */
@@ -83,6 +116,11 @@ class mempool {
       Logging.logWarn(
         `websocket ${reason}; reconnecting in ${this._reconnectDelay}ms`
       );
+      // Notify once per "down" episode (guarded so a flapping socket doesn't spam).
+      if (this._wasConnected) {
+        this._wasConnected = false;
+        telegram.notify(formatConnection(false));
+      }
       // Tear down the old provider before scheduling a new one.
       this._wsprovider.removeAllListeners();
       this._wsprovider.destroy().catch(() => {});
@@ -100,6 +138,11 @@ class mempool {
       // Healthy connection: reset backoff.
       this._reconnectDelay = RECONNECT_MIN_DELAY;
       Logging.logSuccess("websocket connected");
+      // Notify once per "up" transition (not on every reconnect attempt).
+      if (!this._wasConnected) {
+        this._wasConnected = true;
+        telegram.notify(formatConnection(true));
+      }
     });
     // Surface the real reason so endpoint/auth/unsupported-subscription issues
     // are diagnosable (e.g. "closed (code 1006)", "errored: Unexpected server
@@ -162,6 +205,7 @@ class mempool {
 
     const swap = HelpersWrapper.extractSwapDetails(parsed, txReceipt.value);
     if (!swap) return;
+    this._v2Targets++;
 
     const gas = HelpersWrapper.parseGas(txReceipt);
 
@@ -295,6 +339,7 @@ class mempool {
       return;
     }
 
+    this._profitable++;
     Logging.logSuccess(`profitable sandwich for ${hash}`);
     console.log({
       pair: reserves.pair,
@@ -398,6 +443,7 @@ class mempool {
       return;
     }
 
+    this._v3Targets++;
     Logging.logInfo("v3 target swap detected");
     console.log({
       hash: txReceipt.hash,

--- a/src/notify/format.ts
+++ b/src/notify/format.ts
@@ -68,3 +68,34 @@ export function formatBacktestSummary(r: BacktestReport): string {
     `best single: ${eth(r.bestNet)} WETH${r.bestLabel ? ` (${r.bestLabel})` : ""}`,
   ].join("\n");
 }
+
+/** Sent once when the mempool monitor starts. */
+export function formatStartup(dryRun: boolean): string {
+  return [
+    `🤖 *sando-mev started*${dryRun ? " _(DRY_RUN)_" : ""}`,
+    `monitoring the mempool — alerts will arrive when a profitable opportunity is found.`,
+  ].join("\n");
+}
+
+/** Sent on a websocket connect/disconnect transition. */
+export function formatConnection(connected: boolean): string {
+  return connected
+    ? `🟢 *websocket connected* — watching pending transactions.`
+    : `🔴 *websocket disconnected* — reconnecting…`;
+}
+
+/** Periodic "still alive" summary with running counters. */
+export function formatHeartbeat(p: {
+  uptimeMinutes: number;
+  v2Targets: number;
+  v3Targets: number;
+  profitable: number;
+  dryRun: boolean;
+}): string {
+  return [
+    `💓 *sando-mev heartbeat*${p.dryRun ? " _(DRY_RUN)_" : ""}`,
+    `uptime: ${p.uptimeMinutes}m`,
+    `v2 targets: ${p.v2Targets} | v3 targets: ${p.v3Targets}`,
+    `profitable found: ${p.profitable}`,
+  ].join("\n");
+}

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -5,6 +5,9 @@ import {
   formatSandwichAlert,
   formatBackrunAlert,
   formatBacktestSummary,
+  formatStartup,
+  formatConnection,
+  formatHeartbeat,
 } from "../src/notify/format";
 import { test } from "./harness";
 
@@ -80,6 +83,29 @@ test("formatBackrunAlert: includes venues and gross profit", () => {
   assert.ok(msg.includes("Backrun arb"));
   assert.ok(msg.includes("uniswapv2 ↔ sushiswap"));
   assert.ok(msg.includes("0.03 WETH"));
+});
+
+test("formatStartup: notes DRY_RUN", () => {
+  assert.ok(formatStartup(true).includes("DRY_RUN"));
+  assert.ok(formatStartup(false).includes("started"));
+});
+
+test("formatConnection: distinguishes up vs down", () => {
+  assert.ok(formatConnection(true).includes("connected"));
+  assert.ok(formatConnection(false).includes("disconnected"));
+});
+
+test("formatHeartbeat: includes uptime and counters", () => {
+  const msg = formatHeartbeat({
+    uptimeMinutes: 42,
+    v2Targets: 7,
+    v3Targets: 99,
+    profitable: 1,
+    dryRun: true,
+  });
+  assert.ok(msg.includes("42m"));
+  assert.ok(msg.includes("v2 targets: 7"));
+  assert.ok(msg.includes("profitable found: 1"));
 });
 
 test("formatBacktestSummary: includes hit rate and net total", () => {


### PR DESCRIPTION
## Summary

Adds status visibility to `npm start` so you can see on Telegram that it's alive — without spamming. (Profitable-opportunity alerts were already wired into `npm start`; this fills the "is it even working?" gap during quiet periods.)

## What it adds
- **Startup ping** — a message when the mempool monitor launches (notes `DRY_RUN`).
- **Connect/disconnect alerts** — on websocket transitions, **guarded to one message per transition** so a flapping socket doesn't flood you.
- **Heartbeat** — periodic "still alive" summary (`HEARTBEAT_MINUTES`, default 30; `0` disables) with running counters: uptime, V2 targets seen, V3 targets seen, profitable found.

Deliberately **not** added: a Telegram ping per detected swap — V3 volume on mainnet would flood the chat and hit rate limits (you saw that firehose in the console).

## Verification
- `npm test` → **44/44** (3 new formatter tests); `tsc --noEmit` clean; contract compiles.

## To use
Already on by default once Telegram is configured. Tune or disable the heartbeat with `HEARTBEAT_MINUTES` in `.env` (e.g. `0` to turn it off, `10` for every 10 min).

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_