### PR TITLE
fix(notify): Telegram 400 "can't parse entities" — send plain text

### DIFF
--- a/src/notify/format.ts
+++ b/src/notify/format.ts
@@ -6,7 +6,12 @@ import { BacktestReport } from "../backtest/engine";
 
 /**
  * Pure formatters for Telegram alerts. Kept separate from the transport so they
- * can be unit-tested. Output is Telegram Markdown.
+ * can be unit-tested.
+ *
+ * Messages are PLAIN TEXT (the notifier sends with no parse_mode). We avoid
+ * Markdown deliberately: dynamic content here includes underscores (e.g.
+ * "DRY_RUN"), em dashes, and parentheses that break Telegram's legacy Markdown
+ * entity parser ("Bad Request: can't parse entities").
  */
 const eth = (v: BigNumber) => utils.formatEther(v);
 
@@ -25,15 +30,15 @@ export function formatSandwichAlert(params: {
   const { hash, tokenIn, token, pair, quote, grossProfitWeth, decision, dryRun } =
     params;
   return [
-    `🥪 *Sandwich opportunity*${dryRun ? " _(DRY_RUN)_" : ""}`,
-    `tokenIn: \`${tokenIn}\``,
-    `tokenOut: \`${token}\``,
-    `pair: \`${pair}\``,
+    `🥪 Sandwich opportunity${dryRun ? " (DRY_RUN)" : ""}`,
+    `tokenIn: ${tokenIn}`,
+    `tokenOut: ${token}`,
+    `pair: ${pair}`,
     `frontrun in: ${quote.frontrunIn.toString()} (tokenIn)`,
     `gross: ${eth(grossProfitWeth)} WETH`,
     `gas: ${eth(decision.gasCost)} | bribe: ${eth(decision.bribe)} WETH`,
-    `*net: ${eth(decision.netProfit)} WETH*`,
-    `tx: \`${hash}\``,
+    `net: ${eth(decision.netProfit)} WETH`,
+    `tx: ${hash}`,
   ].join("\n");
 }
 
@@ -46,25 +51,25 @@ export function formatBackrunAlert(params: {
 }): string {
   const { hash, token, venues, quote } = params;
   return [
-    `🛰️ *Backrun arb opportunity*`,
-    `token: \`${token}\``,
+    `🛰️ Backrun arb opportunity`,
+    `token: ${token}`,
     `venues: ${venues.join(" ↔ ")}`,
     `direction: ${quote.direction}`,
     `amount in: ${eth(quote.amountIn)} WETH`,
-    `*gross: ${eth(quote.profit)} WETH*`,
-    `hint: \`${hash}\``,
+    `gross: ${eth(quote.profit)} WETH`,
+    `hint: ${hash}`,
   ].join("\n");
 }
 
 /** Summary of a backtest run. */
 export function formatBacktestSummary(r: BacktestReport): string {
   return [
-    `📊 *Backtest complete*`,
+    `📊 Backtest complete`,
     `scenarios: ${r.scenarios} | feasible: ${r.feasible} | profitable: ${r.profitable}`,
     `hit rate: ${(r.hitRate * 100).toFixed(1)}%`,
     `gross: ${eth(r.grossProfitTotal)} | gas: ${eth(r.gasCostTotal)} WETH`,
     `bribe: ${eth(r.bribeTotal)} WETH`,
-    `*net total: ${eth(r.netProfitTotal)} WETH*`,
+    `net total: ${eth(r.netProfitTotal)} WETH`,
     `best single: ${eth(r.bestNet)} WETH${r.bestLabel ? ` (${r.bestLabel})` : ""}`,
   ].join("\n");
 }
@@ -72,7 +77,7 @@ export function formatBacktestSummary(r: BacktestReport): string {
 /** Sent once when the mempool monitor starts. */
 export function formatStartup(dryRun: boolean): string {
   return [
-    `🤖 *sando-mev started*${dryRun ? " _(DRY_RUN)_" : ""}`,
+    `🤖 sando-mev started${dryRun ? " (DRY_RUN)" : ""}`,
     `monitoring the mempool — alerts will arrive when a profitable opportunity is found.`,
   ].join("\n");
 }
@@ -80,8 +85,8 @@ export function formatStartup(dryRun: boolean): string {
 /** Sent on a websocket connect/disconnect transition. */
 export function formatConnection(connected: boolean): string {
   return connected
-    ? `🟢 *websocket connected* — watching pending transactions.`
-    : `🔴 *websocket disconnected* — reconnecting…`;
+    ? `🟢 websocket connected — watching pending transactions.`
+    : `🔴 websocket disconnected — reconnecting…`;
 }
 
 /** Periodic "still alive" summary with running counters. */
@@ -93,7 +98,7 @@ export function formatHeartbeat(p: {
   dryRun: boolean;
 }): string {
   return [
-    `💓 *sando-mev heartbeat*${p.dryRun ? " _(DRY_RUN)_" : ""}`,
+    `💓 sando-mev heartbeat${p.dryRun ? " (DRY_RUN)" : ""}`,
     `uptime: ${p.uptimeMinutes}m`,
     `v2 targets: ${p.v2Targets} | v3 targets: ${p.v3Targets}`,
     `profitable found: ${p.profitable}`,

--- a/src/notify/telegram.ts
+++ b/src/notify/telegram.ts
@@ -72,10 +72,12 @@ export class TelegramNotifier {
   async notify(text: string): Promise<boolean> {
     if (!this.token || !this.chatId) return false;
     try {
+      // Plain text on purpose — no parse_mode. Our messages contain underscores
+      // (DRY_RUN), em dashes and parentheses that break Telegram's Markdown
+      // entity parser ("Bad Request: can't parse entities").
       await this.send(this.token, {
         chat_id: this.chatId,
         text,
-        parse_mode: "Markdown",
         disable_web_page_preview: true,
       });
       return true;

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -34,7 +34,23 @@ test("TelegramNotifier: sends correct payload when configured", async () => {
   assert.strictEqual(sent[0].token, "TOK");
   assert.strictEqual(sent[0].payload.chat_id, "123");
   assert.strictEqual(sent[0].payload.text, "hello");
-  assert.strictEqual(sent[0].payload.parse_mode, "Markdown");
+  // Plain text — no parse_mode (avoids Telegram entity-parse errors).
+  assert.strictEqual(sent[0].payload.parse_mode, undefined);
+});
+
+test("formatters emit no Markdown entity characters", () => {
+  // Guard against the "can't parse entities" 400: messages must be plain text.
+  const samples = [
+    formatStartup(true),
+    formatConnection(true),
+    formatConnection(false),
+    formatHeartbeat({ uptimeMinutes: 1, v2Targets: 0, v3Targets: 0, profitable: 0, dryRun: true }),
+  ];
+  // Underscores (e.g. DRY_RUN) are fine in plain text; only the bold/code
+  // markers we removed would render as literal noise.
+  for (const s of samples) {
+    assert.ok(!/[*`]/.test(s), `unexpected markdown char in: ${s}`);
+  }
 });
 
 test("TelegramNotifier: never throws if transport rejects", async () => {


### PR DESCRIPTION
## Summary

Fixes the `Bad Request: can't parse entities` (HTTP 400) you saw on `npm start`.

**Cause:** messages were sent with `parse_mode=Markdown`, but they contain characters that break Telegram's legacy Markdown entity parser — notably the underscore in **`DRY_RUN`** (Markdown reads `_` as italic, so `DRY_RUN` looks like an unterminated entity), plus em dashes and parentheses.

**Fix:** send **plain text** — drop `parse_mode` and strip the `*` / `_` / backtick formatting from all messages (emojis kept). Plain text can't trigger entity-parse errors.

## Changes
- `telegram.ts` — no `parse_mode` in the payload.
- `format.ts` — all formatters rewritten as plain text.
- tests — assert `parse_mode` is unset + a guard that formatters emit no bold/code markers.

## Verification
- `npm test` → **45/45**; `tsc --noEmit` clean.

After merging: `git pull` and restart `npm start` — the 🤖 startup and 🟢 connected pings will now arrive in Telegram instead of 400-ing.

https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_