### PR TITLE
backrun strategy: MEV Blocker orderflow source + broader venues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,15 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 # Minutes between "still alive" heartbeat messages on npm start (0 disables). Default 30.
 HEARTBEAT_MINUTES=30
+
+# --- Backrun strategy (MEV-Share / MEV Blocker) ---
+# Extra V2 venues for cross-pool arbitrage: "name:factory,name:factory".
+V2_VENUES_EXTRA=
+# MEV Blocker searcher stream (listen-only validator). Default endpoint shown.
+MEVBLOCKER_WS_URL=wss://searchers.mevblocker.io
+# Set true to run the MEV Blocker validator (npm run mevblocker:validate).
+MEVBLOCKER_ENABLED=false
+# Min gross WETH profit to flag a backrun candidate. Default 0.005.
+ARB_MIN_PROFIT_ETH=0.005
+# Cap (ETH) on the arb cycle size. Default 50.
+ARB_MAX_IN_ETH=50

--- a/README.md
+++ b/README.md
@@ -93,8 +93,14 @@ math — to measure whether real backrun edge exists before building the live
 path. **It never submits anything.**
 
 ```
-npm run mevshare:validate
+npm run mevshare:validate     # source: Flashbots MEV-Share hint stream
+npm run mevblocker:validate    # source: MEV Blocker searcher stream (private orderflow)
 ```
+
+`mevblocker:validate` taps the swaps that have left the public mempool, simulates
+each one's pool impact, and estimates a cross-venue backrun across the configured
+V2 venues. Add more venues with `V2_VENUES_EXTRA="name:factory,…"` in `.env`. Both
+are listen-only and never submit.
 
 # tech-stack
 - `Typerscript`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.3.3",
+        "@types/ws": "^7.4.7",
         "solc": "^0.8.35",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
@@ -823,6 +824,16 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/acorn": {
       "version": "8.9.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "compile:contracts": "node scripts/compile.js",
     "backtest": "ts-node src/backtest/cli.ts",
     "mevshare:validate": "ts-node src/mevshare/validate.ts",
+    "mevblocker:validate": "ts-node src/mevblocker/validate.ts",
     "telegram:chatid": "ts-node src/notify/chatid.ts",
     "telegram:test": "ts-node src/notify/test.ts",
     "start": "ts-node-dev  src/index.ts"
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.3.3",
+    "@types/ws": "^7.4.7",
     "solc": "^0.8.35",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,17 @@ const parseAddressList = (v?: string): string[] =>
     .map((a) => a.trim().toLowerCase())
     .filter((a) => a.length > 0);
 
+// Parse "name:factory,name:factory" into venue entries.
+const parseVenues = (v?: string): { name: string; factory: string }[] =>
+  (v ?? "")
+    .split(",")
+    .map((pair) => pair.trim())
+    .filter((pair) => pair.includes(":"))
+    .map((pair) => {
+      const [name, factory] = pair.split(":");
+      return { name: name.trim(), factory: factory.trim() };
+    });
+
 // Accept either WSS_URL or the older RPC_URL_WSS name used in .env.example.
 const WSS_URL = process.env.WSS_URL ?? process.env.RPC_URL_WSS;
 
@@ -82,10 +93,31 @@ export const config = {
   // Only log backrun candidates whose gross WETH profit clears this floor.
   ARB_MIN_PROFIT_WEI: ethersParseEther(process.env.ARB_MIN_PROFIT_ETH ?? "0.005"),
   // V2-compatible venues compared for cross-pool arbitrage (name -> factory).
+  // Extend with V2_VENUES_EXTRA="name:factory,name:factory" in .env.
   V2_VENUES: [
     { name: "uniswapv2", factory: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f" },
     { name: "sushiswap", factory: "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac" },
+    ...parseVenues(process.env.V2_VENUES_EXTRA),
   ],
+
+  // Router -> factory, so we can resolve which pool a pending swap will hit
+  // (used by the MEV Blocker source, which delivers the pending tx pre-exec).
+  V2_ROUTER_FACTORIES: [
+    {
+      router: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
+      factory: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+    }, // uniswap v2
+    {
+      router: "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F",
+      factory: "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
+    }, // sushiswap
+  ],
+
+  // --- MEV Blocker orderflow source (listen-only) ----------------------------
+  MEVBLOCKER_WS_URL:
+    process.env.MEVBLOCKER_WS_URL ?? "wss://searchers.mevblocker.io",
+  MEVBLOCKER_ENABLED:
+    (process.env.MEVBLOCKER_ENABLED ?? "false").toLowerCase() === "true",
 
   // --- Telegram notifications ------------------------------------------------
   // Set both in .env. NEVER commit real values (the .env is gitignored).

--- a/src/mevblocker/client.ts
+++ b/src/mevblocker/client.ts
@@ -1,0 +1,89 @@
+import WebSocket from "ws";
+import { Logging } from "../logging/logging";
+
+/**
+ * Listen-only MEV Blocker searcher stream.
+ *
+ * Searchers connect to the MEV Blocker searcher websocket and
+ * `eth_subscribe("mevblocker_partialPendingTransactions")` to receive unsigned
+ * pending transactions (the orderflow that has left the public mempool). This
+ * client only listens — it never submits `eth_sendBundle` — so no auth is
+ * needed. Auto-reconnects with capped backoff.
+ *
+ * Ref: https://docs.mevblocker.io/how-to/searchers/bid
+ */
+export interface PartialPendingTx {
+  hash?: string;
+  to?: string;
+  /** Calldata — MEV Blocker uses `input` (some feeds use `data`). */
+  input?: string;
+  data?: string;
+  value?: string;
+}
+
+export class MevBlockerStream {
+  private _ws?: WebSocket;
+  private _stopped = false;
+  private _delay = 1_000;
+  private readonly _maxDelay = 30_000;
+  private _id = 1;
+
+  constructor(
+    private readonly url: string,
+    private readonly onTx: (tx: PartialPendingTx) => void
+  ) {}
+
+  start() {
+    this._stopped = false;
+    this.connect();
+  }
+
+  stop() {
+    this._stopped = true;
+    this._ws?.close();
+  }
+
+  private connect() {
+    const ws = new WebSocket(this.url);
+    this._ws = ws;
+
+    ws.on("open", () => {
+      this._delay = 1_000;
+      Logging.logSuccess("mev-blocker stream connected");
+      ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: this._id++,
+          method: "eth_subscribe",
+          params: ["mevblocker_partialPendingTransactions"],
+        })
+      );
+    });
+    ws.on("message", (data: WebSocket.Data) =>
+      this.onMessage(data.toString())
+    );
+    ws.on("close", () => this.scheduleReconnect());
+    ws.on("error", (err) => Logging.logError(err)); // a 'close' follows
+  }
+
+  private onMessage(raw: string) {
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    // Subscription notifications: { method: "eth_subscription", params: { result } }
+    if (msg?.method === "eth_subscription" && msg.params?.result) {
+      this.onTx(msg.params.result as PartialPendingTx);
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this._stopped) return;
+    const delay = this._delay;
+    this._delay = Math.min(this._delay * 2, this._maxDelay);
+    Logging.logWarn(`mev-blocker stream dropped; reconnecting in ${delay}ms`);
+    setTimeout(() => this.connect(), delay);
+  }
+}

--- a/src/mevblocker/validate.ts
+++ b/src/mevblocker/validate.ts
@@ -1,0 +1,14 @@
+import { BackrunValidator } from "../mevshare/validator";
+import { MevBlockerBackrunValidator } from "./validator";
+import { Logging } from "../logging/logging";
+
+// Entry point: `npm run mevblocker:validate`
+// Runs the MEV Blocker backrun edge validator (listen-only). Optionally also
+// runs the MEV-Share validator in the same process so both orderflow sources
+// feed alerts (set MEVSHARE_ALSO=true).
+new MevBlockerBackrunValidator().start();
+
+if ((process.env.MEVSHARE_ALSO ?? "false").toLowerCase() === "true") {
+  Logging.logInfo("also starting MEV-Share validator");
+  new BackrunValidator().start();
+}

--- a/src/mevblocker/validator.ts
+++ b/src/mevblocker/validator.ts
@@ -1,0 +1,160 @@
+import { BigNumber, ethers } from "ethers";
+import { config } from "../config/config";
+import { Logging } from "../logging/logging";
+import { UniswapV2RouterABI } from "../abi";
+import { HelpersWrapper, SANDWICHABLE_METHODS } from "../utils";
+import { MultiVenueV2 } from "../mevshare/venues";
+import { applySwapToReserves, optimalCrossPoolArb, Pool } from "../mevshare/arb";
+import { MevBlockerStream, PartialPendingTx } from "./client";
+import { telegram } from "../notify/telegram";
+import { formatBackrunAlert } from "../notify/format";
+
+/**
+ * Listen-only MEV Blocker backrun edge validator.
+ *
+ * MEV Blocker streams the (private) pending swaps that have left the public
+ * mempool. For each WETH-funded V2 swap we recognise, we simulate its effect on
+ * the pool it hits, then look for a profitable cross-venue backrun with our
+ * existing arb math. It NEVER submits a bundle — it measures whether real
+ * backrun edge reaches us before we build the executor. (See
+ * docs/MEV_SHARE_RESEARCH.md.)
+ *
+ * First cut: WETH-input, direct 2-hop swaps on a known V2 router.
+ */
+export class MevBlockerBackrunValidator {
+  private _venues = new MultiVenueV2();
+  private _router = new ethers.utils.Interface(UniswapV2RouterABI);
+  private _factories: Map<string, string>; // router -> factory
+  private _venueByFactory: Map<string, string>; // factory -> venue name
+  private _weth = config.WETH.toLowerCase();
+  private _stream: MevBlockerStream;
+
+  private _seen = 0;
+  private _candidates = 0;
+  private _bestProfit = BigNumber.from(0);
+
+  constructor() {
+    this._factories = new Map(
+      config.V2_ROUTER_FACTORIES.map((r) => [
+        r.router.toLowerCase(),
+        r.factory.toLowerCase(),
+      ])
+    );
+    this._venueByFactory = new Map(
+      config.V2_VENUES.map((v) => [v.factory.toLowerCase(), v.name])
+    );
+    this._stream = new MevBlockerStream(config.MEVBLOCKER_WS_URL, (tx) =>
+      this.onTx(tx)
+    );
+  }
+
+  start() {
+    Logging.logInfo(
+      `MEV Blocker backrun validator (listen-only) -> ${config.MEVBLOCKER_WS_URL}`
+    );
+    this._stream.start();
+  }
+
+  private onTx = async (tx: PartialPendingTx) => {
+    this._seen++;
+    try {
+      await this.evaluate(tx);
+    } catch (error) {
+      Logging.logError(error);
+    }
+  };
+
+  private async evaluate(tx: PartialPendingTx) {
+    const to = (tx.to ?? "").toLowerCase();
+    const factory = this._factories.get(to);
+    if (!factory) return; // not a known V2 router
+
+    const data = tx.input ?? tx.data;
+    if (!data) return;
+
+    let parsed: ethers.utils.TransactionDescription;
+    try {
+      parsed = this._router.parseTransaction({ data });
+    } catch {
+      return;
+    }
+    if (!SANDWICHABLE_METHODS.has(parsed.name)) return;
+
+    const swap = HelpersWrapper.extractSwapDetails(
+      parsed,
+      BigNumber.from(tx.value ?? 0)
+    );
+    if (
+      !swap ||
+      swap.kind !== "exactIn" ||
+      swap.amountIn == null ||
+      swap.path.length !== 2
+    ) {
+      return;
+    }
+
+    const tokenIn = swap.path[0].toLowerCase();
+    const tokenOut = swap.path[1].toLowerCase();
+    if (tokenIn !== this._weth) return; // WETH-input only (first cut)
+
+    const venues = await this._venues.reservesAcrossVenues(this._weth, tokenOut);
+    if (venues.length < 2) return; // need at least two venues to arb
+
+    const hitVenue = this._venueByFactory.get(factory);
+    const hit = venues.find((v) => v.venue === hitVenue);
+    if (!hit) return; // can't locate the pool the swap hits
+
+    // Simulate the victim's WETH-in swap on the hit pool.
+    const post = applySwapToReserves(
+      swap.amountIn,
+      hit.reserveWeth,
+      hit.reserveToken
+    );
+    const hitPool: Pool = {
+      reserveWeth: post.reserveIn,
+      reserveToken: post.reserveOut,
+    };
+
+    let best: ReturnType<typeof optimalCrossPoolArb> = null;
+    let bestVenue = "";
+    for (const v of venues) {
+      if (v.venue === hitVenue) continue;
+      const other: Pool = {
+        reserveWeth: v.reserveWeth,
+        reserveToken: v.reserveToken,
+      };
+      const q = optimalCrossPoolArb(hitPool, other, config.ARB_MAX_IN_WEI);
+      if (q && (!best || q.profit.gt(best.profit))) {
+        best = q;
+        bestVenue = v.venue;
+      }
+    }
+
+    if (!best || best.profit.lt(config.ARB_MIN_PROFIT_WEI)) return;
+
+    this._candidates++;
+    if (best.profit.gt(this._bestProfit)) this._bestProfit = best.profit;
+
+    Logging.logSuccess(`mev-blocker backrun candidate (${tx.hash ?? "?"})`);
+    console.log({
+      token: tokenOut,
+      venues: [hitVenue, bestVenue],
+      amountInWeth: ethers.utils.formatEther(best.amountIn),
+      grossProfitWeth: ethers.utils.formatEther(best.profit),
+      sessionTotals: {
+        seen: this._seen,
+        candidates: this._candidates,
+        bestProfitWeth: ethers.utils.formatEther(this._bestProfit),
+      },
+    });
+
+    await telegram.notify(
+      formatBackrunAlert({
+        hash: tx.hash ?? "",
+        token: tokenOut,
+        venues: [hitVenue ?? "?", bestVenue],
+        quote: best,
+      })
+    );
+  }
+}

--- a/src/mevshare/arb.ts
+++ b/src/mevshare/arb.ts
@@ -32,6 +32,22 @@ export interface ArbQuote {
 
 const ZERO = BigNumber.from(0);
 
+/**
+ * Apply an exact-input swap of `amountIn` (the "in" token) to a pool and return
+ * its post-swap reserves. Used by orderflow sources that deliver the pending tx
+ * *before* execution (mempool / MEV Blocker), where we must simulate the swap's
+ * effect on the pool to know the reserves a backrun would act on. (MEV-Share, by
+ * contrast, leaks the post-swap Sync reserves directly.)
+ */
+export function applySwapToReserves(
+  amountIn: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber
+): { reserveIn: BigNumber; reserveOut: BigNumber } {
+  const out = getAmountOut(amountIn, reserveIn, reserveOut);
+  return { reserveIn: reserveIn.add(amountIn), reserveOut: reserveOut.sub(out) };
+}
+
 /** WETH out from cycling `amountIn` WETH: buy token on `buy`, sell it on `sell`. */
 function cycleProfit(amountIn: BigNumber, buy: Pool, sell: Pool): BigNumber {
   if (amountIn.lte(0)) return ZERO;

--- a/tests/arb.test.ts
+++ b/tests/arb.test.ts
@@ -1,10 +1,38 @@
 import assert from "assert";
 import { BigNumber, utils } from "ethers";
-import { optimalCrossPoolArb, Pool } from "../src/mevshare/arb";
+import {
+  optimalCrossPoolArb,
+  applySwapToReserves,
+  Pool,
+} from "../src/mevshare/arb";
 import { getAmountOut } from "../src/core/poolMath";
 import { test } from "./harness";
 
 const eth = (v: string) => utils.parseEther(v);
+
+test("applySwapToReserves: moves reserves consistently with getAmountOut", () => {
+  const rIn = eth("100");
+  const rOut = eth("200000");
+  const amountIn = eth("5");
+  const out = getAmountOut(amountIn, rIn, rOut);
+  const post = applySwapToReserves(amountIn, rIn, rOut);
+  assert.strictEqual(post.reserveIn.toString(), rIn.add(amountIn).toString());
+  assert.strictEqual(post.reserveOut.toString(), rOut.sub(out).toString());
+  // Constant-product invariant grows (fee accrues): k_after >= k_before.
+  assert.ok(post.reserveIn.mul(post.reserveOut).gte(rIn.mul(rOut)));
+});
+
+test("applySwapToReserves then arb: a big swap opens a cross-venue gap", () => {
+  // Two equal pools; a large WETH buy on pool A should make A's token dearer,
+  // creating a profitable buy-on-B / sell-on-A backrun.
+  const a: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  const b: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };
+  const post = applySwapToReserves(eth("20"), a.reserveWeth, a.reserveToken);
+  const hit: Pool = { reserveWeth: post.reserveIn, reserveToken: post.reserveOut };
+  const q = optimalCrossPoolArb(hit, b, eth("50"));
+  assert.ok(q, "expected a backrun arb after the swap");
+  assert.ok(q!.profit.gt(0), `expected positive profit, got ${q!.profit}`);
+});
 
 test("optimalCrossPoolArb: no profit when pools are identical", () => {
   const p: Pool = { reserveWeth: eth("100"), reserveToken: eth("200000") };


### PR DESCRIPTION
## Summary

Commits to the strategy we settled on — **backrun-arbitrage** — and widens its surface, since opportunity count scales with how much orderflow + how many venues you can see. The key insight: the profitable swaps have **left the public mempool** for private RPCs, so this taps them directly.

## What's new
- **MEV Blocker source** (`npm run mevblocker:validate`) — a **second orderflow source** alongside MEV-Share. Listen-only client connects to the MEV Blocker searcher websocket and `eth_subscribe("mevblocker_partialPendingTransactions")` (verified against [their docs](https://docs.mevblocker.io/how-to/searchers/bid)). For each WETH-funded V2 swap it: decodes the pending tx, **simulates its impact on the pool it hits**, and estimates a profitable **cross-venue backrun** with our existing arb math. It **never submits** — measures edge before we build the executor.
- **`applySwapToReserves`** (pure, unit-tested) — simulates a pending swap's effect on pool reserves, so pre-execution sources (MEV Blocker, mempool) can be priced. (MEV-Share already leaks post-swap `Sync` reserves.)
- **Broader venues** — `V2_VENUES_EXTRA="name:factory,…"` in `.env` adds V2 venues with no code change; a router→factory map lets the MEV Blocker path resolve which pool a swap hits.
- `MEVSHARE_ALSO=true` runs both sources in one process.

## Verification
- `npm test` → **47/47** (2 new: `applySwapToReserves` + a swap→gap→backrun integration check); `tsc --noEmit` clean; contract compiles; `npm ci` lockfile consistent (adds `@types/ws` dev dep).

## Honest scope / caveats
- **Listen-only.** Submission (`eth_sendBundle`) + a flash-loan executor are the next step — only worth building if these validators show recurring edge.
- The MEV Blocker **partial-tx field mapping** (`to`/`input`/`value`) is coded defensively but should be confirmed against the live feed.
- First cut is **WETH-input, direct 2-hop, V2 venues**. UniswapV3 as an arb venue is the next big lever (needs V3 swap math) — deferred.
- Run it: `MEVBLOCKER_ENABLED=true npm run mevblocker:validate` with your `RPC_URL` set, and watch Telegram for backrun candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_