### PR TITLE
backrun: add UniswapV3 pools as arbitrage venues

### DIFF
--- a/src/core/poolMath.ts
+++ b/src/core/poolMath.ts
@@ -12,16 +12,22 @@ const FEE_NUMERATOR = BigNumber.from(997);
 const FEE_DENOMINATOR = BigNumber.from(1000);
 const ZERO = BigNumber.from(0);
 
-/** Exact analogue of UniswapV2Library.getAmountOut. */
+/**
+ * Constant-product getAmountOut. `feeBps` defaults to 30 (the UniswapV2 0.30%
+ * fee, identical to the classic 997/1000), and is parameterised so other fee
+ * tiers — e.g. UniswapV3 pools modelled as virtual constant-product reserves —
+ * can reuse the same math (500 => 5bps, 3000 => 30bps, 10000 => 100bps).
+ */
 export function getAmountOut(
   amountIn: BigNumber,
   reserveIn: BigNumber,
-  reserveOut: BigNumber
+  reserveOut: BigNumber,
+  feeBps = 30
 ): BigNumber {
   if (amountIn.lte(0) || reserveIn.lte(0) || reserveOut.lte(0)) return ZERO;
-  const amountInWithFee = amountIn.mul(FEE_NUMERATOR);
+  const amountInWithFee = amountIn.mul(10_000 - feeBps);
   const numerator = amountInWithFee.mul(reserveOut);
-  const denominator = reserveIn.mul(FEE_DENOMINATOR).add(amountInWithFee);
+  const denominator = reserveIn.mul(10_000).add(amountInWithFee);
   return numerator.div(denominator);
 }
 

--- a/src/mevblocker/validator.ts
+++ b/src/mevblocker/validator.ts
@@ -5,6 +5,7 @@ import { UniswapV2RouterABI } from "../abi";
 import { HelpersWrapper, SANDWICHABLE_METHODS } from "../utils";
 import { MultiVenueV2 } from "../mevshare/venues";
 import { applySwapToReserves, optimalCrossPoolArb, Pool } from "../mevshare/arb";
+import { v3Venues } from "../mevshare/v3venues";
 import { MevBlockerStream, PartialPendingTx } from "./client";
 import { telegram } from "../notify/telegram";
 import { formatBackrunAlert } from "../notify/format";
@@ -115,18 +116,26 @@ export class MevBlockerBackrunValidator {
       reserveToken: post.reserveOut,
     };
 
+    // Counterparties: the other V2 venues plus any UniswapV3 pools (modelled as
+    // virtual constant-product reserves). The V3 pools are at live state — they
+    // aren't touched by the victim's V2 swap — so they're valid arb targets.
+    const counterparties: { venue: string; pool: Pool }[] = [
+      ...venues
+        .filter((v) => v.venue !== hitVenue)
+        .map((v) => ({
+          venue: v.venue,
+          pool: { reserveWeth: v.reserveWeth, reserveToken: v.reserveToken },
+        })),
+      ...(await v3Venues(this._weth, tokenOut)),
+    ];
+
     let best: ReturnType<typeof optimalCrossPoolArb> = null;
     let bestVenue = "";
-    for (const v of venues) {
-      if (v.venue === hitVenue) continue;
-      const other: Pool = {
-        reserveWeth: v.reserveWeth,
-        reserveToken: v.reserveToken,
-      };
-      const q = optimalCrossPoolArb(hitPool, other, config.ARB_MAX_IN_WEI);
+    for (const cp of counterparties) {
+      const q = optimalCrossPoolArb(hitPool, cp.pool, config.ARB_MAX_IN_WEI);
       if (q && (!best || q.profit.gt(best.profit))) {
         best = q;
-        bestVenue = v.venue;
+        bestVenue = cp.venue;
       }
     }
 

--- a/src/mevshare/arb.ts
+++ b/src/mevshare/arb.ts
@@ -19,6 +19,32 @@ export interface Pool {
   reserveWeth: BigNumber;
   /** Token-side reserve. */
   reserveToken: BigNumber;
+  /** Swap fee in basis points (default 30 = 0.30%). V3 pools set their tier. */
+  feeBps?: number;
+}
+
+const Q96 = BigNumber.from(2).pow(96);
+
+/**
+ * Model a UniswapV3 pool as constant-product "virtual reserves" at its current
+ * price. With active liquidity L and price sqrtPriceX96, the virtual reserves
+ * are x = L·2^96 / sqrtP (token0) and y = L·sqrtP / 2^96 (token1); locally
+ * (within the current tick) the pool swaps exactly like a V2 pool with those
+ * reserves and the tier's fee. This lets V3 pools drop into the same arb math.
+ * (It under-models large, tick-crossing swaps — fine for a listen-only estimate.)
+ */
+export function v3VirtualPool(
+  sqrtPriceX96: BigNumber,
+  liquidity: BigNumber,
+  feeTier: number,
+  wethIsToken0: boolean
+): Pool {
+  const token0 = liquidity.mul(Q96).div(sqrtPriceX96); // virtual reserve token0
+  const token1 = liquidity.mul(sqrtPriceX96).div(Q96); // virtual reserve token1
+  const feeBps = Math.round(feeTier / 100); // 3000 -> 30bps
+  return wethIsToken0
+    ? { reserveWeth: token0, reserveToken: token1, feeBps }
+    : { reserveWeth: token1, reserveToken: token0, feeBps };
 }
 
 export interface ArbQuote {
@@ -52,10 +78,10 @@ export function applySwapToReserves(
 function cycleProfit(amountIn: BigNumber, buy: Pool, sell: Pool): BigNumber {
   if (amountIn.lte(0)) return ZERO;
   // WETH -> token on `buy`
-  const tokenOut = getAmountOut(amountIn, buy.reserveWeth, buy.reserveToken);
+  const tokenOut = getAmountOut(amountIn, buy.reserveWeth, buy.reserveToken, buy.feeBps);
   if (tokenOut.lte(0)) return ZERO;
   // token -> WETH on `sell`
-  const wethOut = getAmountOut(tokenOut, sell.reserveToken, sell.reserveWeth);
+  const wethOut = getAmountOut(tokenOut, sell.reserveToken, sell.reserveWeth, sell.feeBps);
   return wethOut.sub(amountIn);
 }
 

--- a/src/mevshare/v3venues.ts
+++ b/src/mevshare/v3venues.ts
@@ -1,0 +1,33 @@
+import { v3PoolReader } from "../core/v3/pool";
+import { v3VirtualPool, Pool } from "./arb";
+
+/** Common UniswapV3 fee tiers to probe for a pair. */
+const FEE_TIERS = [500, 3000, 10000];
+
+export interface ArbVenue {
+  venue: string;
+  pool: Pool;
+}
+
+/**
+ * UniswapV3 pools for (weth, token), modelled as constant-product virtual
+ * reserves so they can be compared against V2 venues in the same arb math.
+ * Returns one entry per fee tier that exists and has active liquidity.
+ */
+export async function v3Venues(
+  weth: string,
+  token: string
+): Promise<ArbVenue[]> {
+  const wethLc = weth.toLowerCase();
+  const out: ArbVenue[] = [];
+  for (const fee of FEE_TIERS) {
+    const state = await v3PoolReader.getState(weth, token, fee);
+    if (!state || state.liquidity.lte(0) || state.sqrtPriceX96.lte(0)) continue;
+    const wethIsToken0 = state.token0 === wethLc;
+    out.push({
+      venue: `univ3-${fee}`,
+      pool: v3VirtualPool(state.sqrtPriceX96, state.liquidity, fee, wethIsToken0),
+    });
+  }
+  return out;
+}

--- a/src/mevshare/validator.ts
+++ b/src/mevshare/validator.ts
@@ -5,6 +5,7 @@ import { MevShareStream } from "./client";
 import { parseHint, HintEvent, SyncHint } from "./hints";
 import { MultiVenueV2 } from "./venues";
 import { optimalCrossPoolArb, Pool } from "./arb";
+import { v3Venues } from "./v3venues";
 import { telegram } from "../notify/telegram";
 import { formatBackrunAlert } from "../notify/format";
 
@@ -79,6 +80,8 @@ export class BackrunValidator {
         : { reserveWeth: v.reserveWeth, reserveToken: v.reserveToken }
     );
     if (!venues.some((v) => v.pool === sync.pool)) pools.push(poolFromHint);
+    // Add UniswapV3 pools (virtual constant-product reserves) as arb venues.
+    for (const v of await v3Venues(this._weth, token)) pools.push(v.pool);
     if (pools.length < 2) return; // need two venues to arb
 
     // Evaluate every venue pairing; keep the best.

--- a/tests/arb.test.ts
+++ b/tests/arb.test.ts
@@ -3,12 +3,59 @@ import { BigNumber, utils } from "ethers";
 import {
   optimalCrossPoolArb,
   applySwapToReserves,
+  v3VirtualPool,
   Pool,
 } from "../src/mevshare/arb";
 import { getAmountOut } from "../src/core/poolMath";
 import { test } from "./harness";
 
 const eth = (v: string) => utils.parseEther(v);
+const Q96 = BigNumber.from(2).pow(96);
+
+test("getAmountOut: feeBps default matches V2 0.30% and lower fee yields more", () => {
+  const rIn = BigNumber.from(1_000_000);
+  const rOut = BigNumber.from(1_000_000);
+  assert.strictEqual(getAmountOut(BigNumber.from(1000), rIn, rOut).toString(), "996");
+  assert.strictEqual(
+    getAmountOut(BigNumber.from(1000), rIn, rOut, 30).toString(),
+    "996"
+  );
+  // 5bps (V3 0.05% tier) returns strictly more than 30bps.
+  assert.ok(
+    getAmountOut(BigNumber.from(1000), rIn, rOut, 5).gt(
+      getAmountOut(BigNumber.from(1000), rIn, rOut, 30)
+    )
+  );
+});
+
+test("v3VirtualPool: price-1 pool gives equal reserves and maps fee tier", () => {
+  const L = eth("1000");
+  // sqrtPriceX96 = Q96 => price 1 => virtual reserves equal.
+  const pool = v3VirtualPool(Q96, L, 3000, true);
+  assert.strictEqual(pool.reserveWeth.toString(), L.toString());
+  assert.strictEqual(pool.reserveToken.toString(), L.toString());
+  assert.strictEqual(pool.feeBps, 30); // 3000 -> 30bps
+});
+
+test("v3VirtualPool: orientation flips with wethIsToken0", () => {
+  const L = eth("1000");
+  const sqrtP = Q96.mul(2); // price 4 (token1/token0)
+  const asToken0 = v3VirtualPool(sqrtP, L, 500, true);
+  const asToken1 = v3VirtualPool(sqrtP, L, 500, false);
+  // Swapping which side is WETH swaps the two reserves.
+  assert.strictEqual(asToken0.reserveWeth.toString(), asToken1.reserveToken.toString());
+  assert.strictEqual(asToken0.reserveToken.toString(), asToken1.reserveWeth.toString());
+  assert.strictEqual(asToken0.feeBps, 5); // 500 -> 5bps
+});
+
+test("arb works across a V2 pool and a V3 virtual pool", () => {
+  // V2 pool priced differently from a V3 pool of the same pair => arb exists.
+  const v2: Pool = { reserveWeth: eth("100"), reserveToken: eth("220000") };
+  const v3 = v3VirtualPool(Q96, eth("150000"), 3000, true); // ~price 1 region
+  const q = optimalCrossPoolArb(v2, v3, eth("50"));
+  assert.ok(q, "expected an arb across V2 and V3");
+  assert.ok(q!.profit.gt(0), `expected positive profit, got ${q!.profit}`);
+});
 
 test("applySwapToReserves: moves reserves consistently with getAmountOut", () => {
   const rIn = eth("100");


### PR DESCRIPTION
## Summary

The next robustness lever: bring **UniswapV3 liquidity** (the deepest on Ethereum) into the backrun arb. This roughly multiplies the venues a backrun can route through, so far more victim swaps produce a profitable cross-venue gap.

## Approach — V3 as virtual constant-product reserves
Rather than reimplement V3 tick-crossing swap math, I model each V3 pool **at its current price** as a constant-product pool with *virtual reserves*:
- `x = L·2^96 / sqrtP` (token0), `y = L·sqrtP / 2^96` (token1)

Within the active tick this is **exact**, and it drops straight into the arb math we already have. (It under-models large tick-crossing swaps — perfectly fine for a *listen-only edge estimate*; a live executor would confirm with `eth_call` before firing.)

## Changes
- `poolMath.getAmountOut` — fee parameterised as **basis points** (default 30 = V2 0.30%, identical to 997/1000) so V3 tiers (5/30/100 bps) reuse it.
- `arb.ts` — `Pool` gains optional `feeBps`; `cycleProfit` is fee-aware; `v3VirtualPool(sqrtPriceX96, liquidity, feeTier, wethIsToken0)` builds a `Pool`.
- `v3venues.ts` — gather V3 pools for a pair across the 500/3000/10000 tiers.
- **Both validators** (MEV Blocker + MEV-Share) now arb against V3 pools too. The V3 pools sit at live state (untouched by the victim's V2 swap), so they're valid counterparties to the post-swap hit pool.

## Verification
- `npm test` → **51/51** (4 new: bps `getAmountOut`, `v3VirtualPool` orientation/fee mapping, and a V2↔V3 arb); `tsc --noEmit` clean; contract compiles.

## Caveats
- Virtual-reserve model is within-tick exact, approximate for large swaps — acceptable for estimation, to be verified on-chain before any live firing.
- Still listen-only. Submission + flash-loan executor remain the gated next step, only worth building if the validators show recurring edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012U99Eujtd6r8JbCx8o9oNb)_